### PR TITLE
Adding settings.local.php reference to settings.php

### DIFF
--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -87,3 +87,17 @@ if (isset($_SERVER['PRESSFLOW_SETTINGS'])) {
  * Prevents fatal error https://github.com/pantheon-systems/drops-8/issues/23
 */
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+
+/**
+ * Load local development override configuration, if available.
+ *
+ * Use settings.local.php to override variables on secondary (staging,
+ * development, etc) installations of this site. Typically used to disable
+ * caching, JavaScript/CSS compression, re-routing of outgoing emails, and
+ * other things that should not happen on development and testing sites.
+ *
+ * Keep this code block at the end of this file to take full effect.
+ */
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}


### PR DESCRIPTION
Makes working on a local copy of the site easier, and removes need to edit the settings file committed to the site's repo.

Code and comments come from core's default.settings.php