### PR TITLE
Add a .drush-lock-update file

### DIFF
--- a/.drush-lock-update
+++ b/.drush-lock-update
@@ -1,0 +1,1 @@
+Do not update via Drush. See: https://pantheon.io/docs/articles/sites/code/applying-upstream-updates/


### PR DESCRIPTION
Tell folks not to update Pantheon Drupal sites with Drush.

In order for this to work, the customer must be running a recent version of Drush.  Only 7.0-rc1 (due out this evening), and current HEAD of 6.x (next release tbd) and 5.x (no further releases) will work.
