### PR TITLE
#37: Some pressflow things dont set drupal_hash_salt explicitly

### DIFF
--- a/sites/default/settings.php
+++ b/sites/default/settings.php
@@ -82,7 +82,12 @@ if (isset($_SERVER['PRESSFLOW_SETTINGS'])) {
  *
  */
 if (isset($_SERVER['PRESSFLOW_SETTINGS'])) {
-  $settings['hash_salt'] = $drupal_hash_salt;
+  if (defined('PANTHEON_ENVIRONMENT')) {
+    $settings['hash_salt'] = $drupal_hash_salt;
+  }
+  else {
+    $settings['hash_salt'] = hash('sha256', serialize($databases));
+  }
 }
 
 /**


### PR DESCRIPTION
this is a better resolution to #37 until we can set this on the server side on KB2