### PR TITLE
Ignore sites/default/files from git to prevent conflicts on Pantheon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Pantheon manages this path as a symlink
+sites/default/files
+
+# Also see the example.gitignore for other helpful
+# patterns to ignore from git.


### PR DESCRIPTION
This will address and existing issue with Drops-8 on Pantheon, whereby the pantheon-generated sites/default/files symlink can be committed via SFTP mode, breaking Pantheon's ability to manage the site after that point.

We can get fancy with the .gitignore file later, but this will resolve the issue at hand.

cc @populist @greg-1-anderson 