### PR TITLE
Add a Pantheon installation profile.

### DIFF
--- a/core/profiles/pantheon/config/install/block.block.bartik_account_menu.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_account_menu.yml
@@ -1,0 +1,22 @@
+id: bartik_account_menu
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: secondary_menu
+plugin: 'system_menu_block:account'
+settings:
+  id: 'system_menu_block:account'
+  label: 'User account menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 1
+dependencies:
+  config:
+    - system.menu.account
+  module:
+    - system
+  theme:
+    - bartik
+visibility: { }

--- a/core/profiles/pantheon/config/install/block.block.bartik_breadcrumbs.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_breadcrumbs.yml
@@ -1,0 +1,18 @@
+id: bartik_breadcrumbs
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: breadcrumb
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_content.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_content.yml
@@ -1,0 +1,18 @@
+id: bartik_content
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: content
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_footer.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_footer.yml
@@ -1,0 +1,22 @@
+id: bartik_footer
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: footer_fifth
+plugin: 'system_menu_block:footer'
+settings:
+  id: 'system_menu_block:footer'
+  label: 'Footer menu'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 0
+dependencies:
+  config:
+    - system.menu.footer
+  module:
+    - system
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_help.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_help.yml
@@ -1,0 +1,18 @@
+id: bartik_help
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: help
+plugin: help_block
+settings:
+  id: help_block
+  label: 'Help'
+  provider: help
+  label_display: '0'
+dependencies:
+  module:
+    - help
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_login.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_login.yml
@@ -1,0 +1,18 @@
+id: bartik_login
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: sidebar_first
+plugin: user_login_block
+settings:
+  id: user_login_block
+  label: 'User login'
+  provider: user
+  label_display: visible
+dependencies:
+  module:
+    - user
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_main_menu.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_main_menu.yml
@@ -1,0 +1,22 @@
+id: bartik_main_menu
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: primary_menu
+plugin: 'system_menu_block:main'
+settings:
+  id: 'system_menu_block:main'
+  label: 'Main navigation'
+  provider: system
+  label_display: '0'
+  level: 1
+  depth: 1
+dependencies:
+  config:
+    - system.menu.main
+  module:
+    - system
+  theme:
+    - bartik
+visibility: {}

--- a/core/profiles/pantheon/config/install/block.block.bartik_messages.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_messages.yml
@@ -1,0 +1,17 @@
+id: bartik_messages
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: highlighted
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - bartik

--- a/core/profiles/pantheon/config/install/block.block.bartik_powered.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_powered.yml
@@ -1,0 +1,18 @@
+id: bartik_powered
+theme: bartik
+weight: 10
+status: true
+langcode: en
+region: footer_fifth
+plugin: system_powered_by_block
+settings:
+  id: system_powered_by_block
+  label: 'Powered by Drupal'
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_search.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_search.yml
@@ -1,0 +1,18 @@
+id: bartik_search
+theme: bartik
+weight: -1
+status: true
+langcode: en
+region: sidebar_first
+plugin: search_form_block
+settings:
+  id: search_form_block
+  label: Search
+  provider: search
+  label_display: visible
+dependencies:
+  module:
+    - search
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.bartik_tools.yml
+++ b/core/profiles/pantheon/config/install/block.block.bartik_tools.yml
@@ -1,0 +1,22 @@
+id: bartik_tools
+theme: bartik
+weight: 0
+status: true
+langcode: en
+region: sidebar_first
+plugin: 'system_menu_block:tools'
+settings:
+  id: 'system_menu_block:tools'
+  label: Tools
+  provider: system
+  label_display: visible
+  level: 1
+  depth: 0
+dependencies:
+  config:
+    - system.menu.tools
+  module:
+    - system
+  theme:
+    - bartik
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.seven_breadcrumbs.yml
+++ b/core/profiles/pantheon/config/install/block.block.seven_breadcrumbs.yml
@@ -1,0 +1,18 @@
+id: seven_breadcrumbs
+theme: seven
+weight: 0
+status: true
+langcode: en
+region: breadcrumb
+plugin: system_breadcrumb_block
+settings:
+  id: system_breadcrumb_block
+  label: Breadcrumbs
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - seven
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.seven_content.yml
+++ b/core/profiles/pantheon/config/install/block.block.seven_content.yml
@@ -1,0 +1,18 @@
+id: seven_content
+theme: seven
+weight: 0
+status: true
+langcode: en
+region: content
+plugin: system_main_block
+settings:
+  id: system_main_block
+  label: 'Main page content'
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - seven
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.seven_help.yml
+++ b/core/profiles/pantheon/config/install/block.block.seven_help.yml
@@ -1,0 +1,18 @@
+id: seven_help
+theme: seven
+weight: 0
+status: true
+langcode: en
+region: help
+plugin: help_block
+settings:
+  id: help_block
+  label: 'Help'
+  provider: help
+  label_display: '0'
+dependencies:
+  module:
+    - help
+  theme:
+    - seven
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.seven_login.yml
+++ b/core/profiles/pantheon/config/install/block.block.seven_login.yml
@@ -1,0 +1,18 @@
+id: seven_login
+theme: seven
+weight: 10
+status: true
+langcode: en
+region: content
+plugin: user_login_block
+settings:
+  id: user_login_block
+  label: 'User login'
+  provider: user
+  label_display: visible
+dependencies:
+  module:
+    - user
+  theme:
+    - seven
+visibility: {  }

--- a/core/profiles/pantheon/config/install/block.block.seven_messages.yml
+++ b/core/profiles/pantheon/config/install/block.block.seven_messages.yml
@@ -1,0 +1,17 @@
+id: seven_messages
+theme: seven
+weight: 0
+status: true
+langcode: en
+region: highlighted
+plugin: system_messages_block
+settings:
+  id: system_messages_block
+  label: 'Status messages'
+  provider: system
+  label_display: '0'
+dependencies:
+  module:
+    - system
+  theme:
+    - seven

--- a/core/profiles/pantheon/config/install/block_content.type.basic.yml
+++ b/core/profiles/pantheon/config/install/block_content.type.basic.yml
@@ -1,0 +1,5 @@
+id: basic
+label: 'Basic block'
+revision: 0
+description: 'A basic block contains a title and a body.'
+langcode: en

--- a/core/profiles/pantheon/config/install/comment.type.comment.yml
+++ b/core/profiles/pantheon/config/install/comment.type.comment.yml
@@ -1,0 +1,6 @@
+id: comment
+label: 'Default comments'
+description: 'Allows commenting on content'
+target_entity_type_id: node
+status: true
+langcode: en

--- a/core/profiles/pantheon/config/install/contact.form.feedback.yml
+++ b/core/profiles/pantheon/config/install/contact.form.feedback.yml
@@ -1,0 +1,7 @@
+id: feedback
+label: 'Website feedback'
+recipients: {  }
+reply: ''
+weight: 0
+status: true
+langcode: en

--- a/core/profiles/pantheon/config/install/core.base_field_override.node.page.promote.yml
+++ b/core/profiles/pantheon/config/install/core.base_field_override.node.page.promote.yml
@@ -1,0 +1,20 @@
+# Changes the default value of the promote base field on the page node type.
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.page
+id: node.page.promote
+field_name: promote
+entity_type: node
+bundle: page
+label: Promoted to front page
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings: {  }
+field_type: boolean

--- a/core/profiles/pantheon/config/install/core.entity_form_display.block_content.basic.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_form_display.block_content.basic.default.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.field.block_content.basic.body
+  module:
+    - text
+id: block_content.basic.default
+targetEntityType: block_content
+bundle: basic
+mode: default
+content:
+  info:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  body:
+    type: text_textarea_with_summary
+    weight: -4
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_form_display.comment.comment.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_form_display.comment.comment.default.yml
@@ -1,0 +1,31 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - field.field.comment.comment.comment_body
+  module:
+    - text
+id: comment.comment.default
+targetEntityType: comment
+bundle: comment
+mode: default
+content:
+  author:
+    weight: -2
+  subject:
+    type: string_textfield
+    weight: 10
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  comment_body:
+    type: text_textarea
+    weight: 11
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_form_display.node.article.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_form_display.node.article.default.yml
@@ -1,0 +1,85 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - node.type.article
+  module:
+    - comment
+    - entity_reference
+    - image
+    - path
+    - taxonomy
+    - text
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  body:
+    type: text_textarea_with_summary
+    weight: 1
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_tags:
+    type: entity_reference_autocomplete_tags
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+  field_image:
+    type: image_image
+    weight: 4
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  comment:
+    type: comment_default
+    weight: 20
+    settings: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_form_display.node.page.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_form_display.node.page.default.yml
@@ -1,0 +1,62 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.page.body
+    - node.type.page
+  module:
+    - entity_reference
+    - path
+    - text
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  title:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
+  body:
+    type: text_textarea_with_summary
+    weight: 31
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_form_display.user.user.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_form_display.user.user.default.yml
@@ -1,0 +1,17 @@
+id: user.user.default
+targetEntityType: user
+bundle: user
+mode: default
+content:
+  user_picture:
+    type: image_image
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    weight: -1
+status: true
+dependencies:
+  module:
+    - image
+    - user

--- a/core/profiles/pantheon/config/install/core.entity_view_display.block_content.basic.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.block_content.basic.default.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.field.block_content.basic.body
+  module:
+    - text
+id: block_content.basic.default
+targetEntityType: block_content
+bundle: basic
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.comment.comment.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.comment.comment.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - field.field.comment.comment.comment_body
+  module:
+    - text
+id: comment.comment.default
+targetEntityType: comment
+bundle: comment
+mode: default
+content:
+  comment_body:
+    label: hidden
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 100
+hidden: {  }
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.node.article.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.node.article.default.yml
@@ -1,0 +1,55 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - node.type.article
+  module:
+    - comment
+    - image
+    - taxonomy
+    - text
+    - user
+id: node.article.default
+targetEntityType: node
+bundle: article
+mode: default
+content:
+  field_image:
+    type: image
+    weight: -1
+    settings:
+      image_style: large
+      image_link: ''
+    third_party_settings: {  }
+    label: hidden
+  body:
+    type: text_default
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    label: hidden
+  field_tags:
+    type: entity_reference_label
+    weight: 10
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+  comment:
+    label: above
+    type: comment_default
+    weight: 20
+    settings:
+      pager_id: 0
+    third_party_settings: {  }
+  links:
+    weight: 100
+hidden:
+  langcode: true
+  field_image: true
+  field_tags: true
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.node.article.rss.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.node.article.rss.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.rss
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - node.type.article
+  module:
+    - user
+id: node.article.rss
+targetEntityType: node
+bundle: article
+mode: rss
+content:
+  links:
+    weight: 100
+hidden:
+  langcode: true
+  body: true
+  comment: true
+  field_image: true
+  field_tags: true
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.node.article.teaser.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.node.article.teaser.yml
@@ -1,0 +1,50 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.article.body
+    - field.field.node.article.comment
+    - field.field.node.article.field_image
+    - field.field.node.article.field_tags
+    - node.type.article
+  module:
+    - image
+    - taxonomy
+    - text
+    - user
+id: node.article.teaser
+targetEntityType: node
+bundle: article
+mode: teaser
+content:
+  field_image:
+    type: image
+    weight: -1
+    settings:
+      image_style: medium
+      image_link: content
+    third_party_settings: {  }
+    label: hidden
+  body:
+    type: text_summary_or_trimmed
+    weight: 0
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    label: hidden
+  field_tags:
+    type: entity_reference_label
+    weight: 10
+    settings:
+      link: true
+    third_party_settings: {  }
+    label: above
+  links:
+    weight: 100
+hidden:
+  langcode: true
+  field_image: true
+  field_tags: true
+  comment: true
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.node.page.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.node.page.default.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.page.body
+    - node.type.page
+  module:
+    - text
+    - user
+id: node.page.default
+targetEntityType: node
+bundle: page
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+  links:
+    weight: 101
+hidden:
+  langcode: true
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.node.page.teaser.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.node.page.teaser.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.page.body
+    - node.type.page
+  module:
+    - text
+    - user
+id: node.page.teaser
+targetEntityType: node
+bundle: page
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 100
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+  links:
+    weight: 101
+hidden:
+  langcode: true
+third_party_settings: {  }

--- a/core/profiles/pantheon/config/install/core.entity_view_display.user.user.compact.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.user.user.compact.yml
@@ -1,0 +1,22 @@
+id: user.user.compact
+targetEntityType: user
+bundle: user
+mode: compact
+content:
+  user_picture:
+    type: image
+    weight: 0
+    settings:
+      image_style: thumbnail
+      image_link: content
+    third_party_settings: {  }
+    label: hidden
+hidden:
+  member_for: true
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.user.compact
+  module:
+    - image
+    - user

--- a/core/profiles/pantheon/config/install/core.entity_view_display.user.user.default.yml
+++ b/core/profiles/pantheon/config/install/core.entity_view_display.user.user.default.yml
@@ -1,0 +1,18 @@
+id: user.user.default
+targetEntityType: user
+bundle: user
+mode: default
+content:
+  user_picture:
+    type: image
+    weight: 0
+    settings:
+      image_style: thumbnail
+      image_link: content
+    third_party_settings: {  }
+    label: hidden
+status: true
+dependencies:
+  module:
+    - image
+    - user

--- a/core/profiles/pantheon/config/install/editor.editor.basic_html.yml
+++ b/core/profiles/pantheon/config/install/editor.editor.basic_html.yml
@@ -1,0 +1,48 @@
+format: basic_html
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+        -
+          name: Linking
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Media
+          items:
+            - Blockquote
+            - DrupalImage
+        -
+          name: Tools
+          items:
+            - Source
+  plugins:
+    stylescombo:
+      styles: ''
+image_upload:
+  status: true
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: 0
+    height: 0
+status: true
+langcode: en
+dependencies:
+  config:
+    - filter.format.basic_html
+  module:
+    - ckeditor

--- a/core/profiles/pantheon/config/install/editor.editor.full_html.yml
+++ b/core/profiles/pantheon/config/install/editor.editor.full_html.yml
@@ -1,0 +1,60 @@
+format: full_html
+editor: ckeditor
+settings:
+  toolbar:
+    rows:
+      -
+        -
+          name: Formatting
+          items:
+            - Bold
+            - Italic
+            - Strike
+            - Superscript
+            - Subscript
+            - -
+            - RemoveFormat
+        -
+          name: Linking
+          items:
+            - DrupalLink
+            - DrupalUnlink
+        -
+          name: Lists
+          items:
+            - BulletedList
+            - NumberedList
+        -
+          name: Media
+          items:
+            - Blockquote
+            - DrupalImage
+            - Table
+            - HorizontalRule
+        -
+          name: 'Block Formatting'
+          items:
+            - Format
+        -
+          name: Tools
+          items:
+            - ShowBlocks
+            - Source
+  plugins:
+    stylescombo:
+      styles: ''
+image_upload:
+  status: true
+  scheme: public
+  directory: inline-images
+  max_size: ''
+  max_dimensions:
+    width: 0
+    height: 0
+status: true
+langcode: en
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - ckeditor

--- a/core/profiles/pantheon/config/install/field.field.block_content.basic.body.yml
+++ b/core/profiles/pantheon/config/install/field.field.block_content.basic.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.basic
+    - field.storage.block_content.body
+  module:
+    - text
+id: block_content.basic.body
+field_name: body
+entity_type: block_content
+bundle: basic
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: false
+third_party_settings: {  }
+field_type: text_with_summary

--- a/core/profiles/pantheon/config/install/field.field.comment.comment.comment_body.yml
+++ b/core/profiles/pantheon/config/install/field.field.comment.comment.comment_body.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+    - field.storage.comment.comment_body
+  module:
+    - text
+id: comment.comment.comment_body
+field_name: comment_body
+entity_type: comment
+bundle: comment
+label: Comment
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+third_party_settings: {  }
+field_type: text_long

--- a/core/profiles/pantheon/config/install/field.field.node.article.body.yml
+++ b/core/profiles/pantheon/config/install/field.field.node.article.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.article
+  module:
+    - text
+id: node.article.body
+field_name: body
+entity_type: node
+bundle: article
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+third_party_settings: {  }
+field_type: text_with_summary

--- a/core/profiles/pantheon/config/install/field.field.node.article.comment.yml
+++ b/core/profiles/pantheon/config/install/field.field.node.article.comment.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.comment
+    - node.type.article
+  module:
+    - comment
+id: node.article.comment
+field_name: comment
+entity_type: node
+bundle: article
+label: Comments
+description: ''
+required: true
+translatable: true
+default_value:
+  -
+    status: 2
+    cid: 0
+    last_comment_name: null
+    last_comment_timestamp: 0
+    last_comment_uid: 0
+    comment_count: 0
+default_value_callback: ''
+settings:
+  default_mode: 1
+  per_page: 50
+  form_location: true
+  anonymous: 0
+  preview: 1
+third_party_settings: {  }
+field_type: comment

--- a/core/profiles/pantheon/config/install/field.field.node.article.field_image.yml
+++ b/core/profiles/pantheon/config/install/field.field.node.article.field_image.yml
@@ -1,0 +1,32 @@
+id: node.article.field_image
+entity_type: node
+bundle: article
+field_name: field_image
+label: Image
+description: ''
+required: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: field/image
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  title_field: false
+  alt_field_required: true
+  title_field_required: false
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+status: true
+langcode: en
+field_type: image
+dependencies:
+  config:
+    - field.storage.node.field_image
+    - node.type.article

--- a/core/profiles/pantheon/config/install/field.field.node.article.field_tags.yml
+++ b/core/profiles/pantheon/config/install/field.field.node.article.field_tags.yml
@@ -1,0 +1,26 @@
+id: node.article.field_tags
+entity_type: node
+bundle: article
+field_name: field_tags
+field_type: entity_reference
+label: Tags
+description: 'Enter a comma-separated list. For example: Amsterdam, Mexico City, "Cleveland, Ohio"'
+required: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings:
+    target_bundles:
+      tags: tags
+    sort:
+      field: _none
+    auto_create: true
+status: true
+langcode: en
+dependencies:
+  config:
+    - field.storage.node.field_tags
+    - node.type.article
+  module:
+    - entity_reference

--- a/core/profiles/pantheon/config/install/field.field.node.page.body.yml
+++ b/core/profiles/pantheon/config/install/field.field.node.page.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.page
+  module:
+    - text
+id: node.page.body
+field_name: body
+entity_type: node
+bundle: page
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+third_party_settings: {  }
+field_type: text_with_summary

--- a/core/profiles/pantheon/config/install/field.field.user.user.user_picture.yml
+++ b/core/profiles/pantheon/config/install/field.field.user.user.user_picture.yml
@@ -1,0 +1,31 @@
+id: user.user.user_picture
+status: true
+langcode: en
+entity_type: user
+bundle: user
+field_name: user_picture
+label: Picture
+description: 'Your virtual face or picture.'
+required: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_extensions: 'png gif jpg jpeg'
+  file_directory: pictures
+  max_filesize: '30 KB'
+  alt_field: false
+  title_field: false
+  max_resolution: 85x85
+  min_resolution: ''
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  alt_field_required: false
+  title_field_required: false
+field_type: image
+dependencies:
+  config:
+    - field.storage.user.user_picture

--- a/core/profiles/pantheon/config/install/field.storage.node.comment.yml
+++ b/core/profiles/pantheon/config/install/field.storage.node.comment.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - node
+id: node.comment
+field_name: comment
+entity_type: node
+type: comment
+settings:
+  comment_type: comment
+module: comment
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false

--- a/core/profiles/pantheon/config/install/field.storage.node.field_image.yml
+++ b/core/profiles/pantheon/config/install/field.storage.node.field_image.yml
@@ -1,0 +1,26 @@
+id: node.field_image
+field_name: field_image
+entity_type: node
+type: image
+module: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+locked: false
+cardinality: 1
+translatable: true
+indexes:
+  target_id:
+    - target_id
+status: true
+langcode: en
+dependencies:
+  module:
+    - node
+    - image
+persist_with_no_fields: false

--- a/core/profiles/pantheon/config/install/field.storage.node.field_tags.yml
+++ b/core/profiles/pantheon/config/install/field.storage.node.field_tags.yml
@@ -1,0 +1,17 @@
+id: node.field_tags
+field_name: field_tags
+entity_type: node
+type: entity_reference
+module: taxonomy
+settings:
+  target_type: taxonomy_term
+locked: false
+cardinality: -1
+translatable: true
+status: true
+langcode: en
+dependencies:
+  module:
+    - node
+    - taxonomy
+persist_with_no_fields: false

--- a/core/profiles/pantheon/config/install/field.storage.user.user_picture.yml
+++ b/core/profiles/pantheon/config/install/field.storage.user.user_picture.yml
@@ -1,0 +1,25 @@
+id: user.user_picture
+status: true
+langcode: en
+field_name: user_picture
+entity_type: user
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: null
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+indexes:
+  target_id:
+    - target_id
+dependencies:
+  module:
+    - image
+    - user
+persist_with_no_fields: false

--- a/core/profiles/pantheon/config/install/filter.format.basic_html.yml
+++ b/core/profiles/pantheon/config/install/filter.format.basic_html.yml
@@ -1,0 +1,50 @@
+format: basic_html
+name: 'Basic HTML'
+status: true
+weight: 0
+roles:
+  - authenticated
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h4> <h5> <h6> <p> <br> <span> <img>'
+      filter_html_help: false
+      filter_html_nofollow: false
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: 7
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: 8
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: true
+    weight: 9
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 11
+    settings: {  }
+langcode: en
+dependencies:
+  module:
+    - editor

--- a/core/profiles/pantheon/config/install/filter.format.full_html.yml
+++ b/core/profiles/pantheon/config/install/filter.format.full_html.yml
@@ -1,0 +1,35 @@
+format: full_html
+name: 'Full HTML'
+status: true
+weight: 1
+roles:
+  - administrator
+filters:
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: true
+    weight: 8
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: true
+    weight: 9
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 11
+    settings: {  }
+langcode: en
+dependencies:
+  module:
+    - editor

--- a/core/profiles/pantheon/config/install/filter.format.restricted_html.yml
+++ b/core/profiles/pantheon/config/install/filter.format.restricted_html.yml
@@ -1,0 +1,36 @@
+format: restricted_html
+name: 'Restricted HTML'
+status: true
+weight: 0
+roles:
+  - anonymous
+filters:
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<a> <em> <strong> <cite> <blockquote> <code> <ul> <ol> <li> <dl> <dt> <dd> <h4> <h5> <h6>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: 0
+    settings:
+      filter_url_length: 72
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: 10
+    settings: {  }
+langcode: en

--- a/core/profiles/pantheon/config/install/node.type.article.yml
+++ b/core/profiles/pantheon/config/install/node.type.article.yml
@@ -1,0 +1,9 @@
+type: article
+name: Article
+description: 'Use <em>articles</em> for time-sensitive content like news, press releases or blog posts.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: true
+status: true
+langcode: en

--- a/core/profiles/pantheon/config/install/node.type.page.yml
+++ b/core/profiles/pantheon/config/install/node.type.page.yml
@@ -1,0 +1,9 @@
+type: page
+name: 'Basic page'
+description: 'Use <em>basic pages</em> for your static content, such as an ''About us'' page.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false
+status: true
+langcode: en

--- a/core/profiles/pantheon/config/install/rdf.mapping.comment.comment.yml
+++ b/core/profiles/pantheon/config/install/rdf.mapping.comment.comment.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - comment.type.comment
+  module:
+    - comment
+id: comment.comment
+targetEntityType: comment
+bundle: comment
+types:
+  - 'schema:Comment'
+fieldMappings:
+  subject:
+    properties:
+      - 'schema:name'
+  created:
+    properties:
+      - 'schema:dateCreated'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  changed:
+    properties:
+      - 'schema:dateModified'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  comment_body:
+    properties:
+      - 'schema:text'
+  uid:
+    properties:
+      - 'schema:author'
+    mapping_type: rel

--- a/core/profiles/pantheon/config/install/rdf.mapping.node.article.yml
+++ b/core/profiles/pantheon/config/install/rdf.mapping.node.article.yml
@@ -1,0 +1,47 @@
+id: node.article
+targetEntityType: node
+bundle: article
+types:
+  - 'schema:Article'
+fieldMappings:
+  title:
+    properties:
+      - 'schema:name'
+  created:
+    properties:
+      - 'schema:dateCreated'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  changed:
+    properties:
+      - 'schema:dateModified'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  body:
+    properties:
+      - 'schema:text'
+  uid:
+    properties:
+      - 'schema:author'
+  comment:
+    properties:
+      - 'schema:comment'
+    mapping_type: 'rel'
+  comment_count:
+    properties:
+      - 'schema:interactionCount'
+    datatype_callback:
+      callable: 'Drupal\rdf\SchemaOrgDataConverter::interactionCount'
+      arguments:
+        interaction_type: 'UserComments'
+  field_image:
+    properties:
+      - 'schema:image'
+  field_tags:
+    properties:
+      - 'schema:about'
+dependencies:
+  config:
+    - node.type.article
+  module:
+    - node

--- a/core/profiles/pantheon/config/install/rdf.mapping.node.page.yml
+++ b/core/profiles/pantheon/config/install/rdf.mapping.node.page.yml
@@ -1,0 +1,38 @@
+id: node.page
+targetEntityType: node
+bundle: page
+types:
+  - 'schema:WebPage'
+fieldMappings:
+  title:
+    properties:
+      - 'schema:name'
+  created:
+    properties:
+      - 'schema:dateCreated'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  changed:
+    properties:
+      - 'schema:dateModified'
+    datatype_callback:
+      callable: 'Drupal\rdf\CommonDataConverter::dateIso8601Value'
+  body:
+    properties:
+      - 'schema:text'
+  uid:
+    properties:
+      - 'schema:author'
+    mapping_type: 'rel'
+  comment_count:
+    properties:
+      - 'schema:interactionCount'
+    datatype_callback:
+      callable: 'Drupal\rdf\SchemaOrgDataConverter::interactionCount'
+      arguments:
+        interaction_type: 'UserComments'
+dependencies:
+  config:
+    - node.type.page
+  module:
+    - node

--- a/core/profiles/pantheon/config/install/rdf.mapping.taxonomy_term.tags.yml
+++ b/core/profiles/pantheon/config/install/rdf.mapping.taxonomy_term.tags.yml
@@ -1,0 +1,17 @@
+id: taxonomy_term.tags
+targetEntityType: taxonomy_term
+bundle: tags
+types:
+  - 'schema:Thing'
+fieldMappings:
+  name:
+    properties:
+      - 'schema:name'
+  description:
+    properties:
+      - 'schema:description'
+dependencies:
+  config:
+    - taxonomy.vocabulary.tags
+  module:
+    - taxonomy

--- a/core/profiles/pantheon/config/install/system.cron.yml
+++ b/core/profiles/pantheon/config/install/system.cron.yml
@@ -1,0 +1,4 @@
+threshold:
+  autorun: 10800
+  requirements_warning: 172800
+  requirements_error: 1209600

--- a/core/profiles/pantheon/config/install/system.theme.yml
+++ b/core/profiles/pantheon/config/install/system.theme.yml
@@ -1,0 +1,2 @@
+admin: seven
+default: bartik

--- a/core/profiles/pantheon/config/install/taxonomy.vocabulary.tags.yml
+++ b/core/profiles/pantheon/config/install/taxonomy.vocabulary.tags.yml
@@ -1,0 +1,7 @@
+vid: tags
+name: Tags
+description: 'Use tags to group articles on similar topics into categories.'
+hierarchy: 0
+weight: 0
+status: true
+langcode: en

--- a/core/profiles/pantheon/config/install/user.role.administrator.yml
+++ b/core/profiles/pantheon/config/install/user.role.administrator.yml
@@ -1,0 +1,5 @@
+id: administrator
+label: Administrator
+weight: 2
+langcode: en
+is_admin: true

--- a/core/profiles/pantheon/pantheon.info.yml
+++ b/core/profiles/pantheon/pantheon.info.yml
@@ -1,0 +1,44 @@
+name: Pantheon
+type: profile
+description: 'Install with pre-configured integration for the Pantheon Platform.'
+version: VERSION
+core: 8.x
+distribution:
+  name: Pantheon
+dependencies:
+  - node
+  - history
+  - block
+  - breakpoint
+  - ckeditor
+  - color
+  - config
+  - comment
+  - contextual
+  - contact
+  - menu_link_content
+  - datetime
+  - block_content
+  - quickedit
+  - editor
+  - entity_reference
+  - help
+  - image
+  - menu_ui
+  - options
+  - path
+  - page_cache
+  - taxonomy
+  - dblog
+  - search
+  - shortcut
+  - toolbar
+  - field_ui
+  - file
+  - rdf
+  - views
+  - views_ui
+  - tour
+themes:
+  - bartik
+  - seven

--- a/core/profiles/pantheon/pantheon.install
+++ b/core/profiles/pantheon/pantheon.install
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @file
+ * Install, update and uninstall functions for the Pantheon install profile.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Perform actions to set up the site for this profile.
+ *
+ * @see system_install()
+ */
+function pantheon_install() {
+  // First, do everything in standard profile.
+  include_once DRUPAL_ROOT . '/core/profiles/standard/standard.install';
+  standard_install();
+}

--- a/core/profiles/pantheon/pantheon.profile
+++ b/core/profiles/pantheon/pantheon.profile
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Enables modules and site configuration for a Pantheon site installation.
+ */
+
+use Drupal\contact\Entity\ContactForm;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_FORM_ID_alter() for install_configure_form().
+ *
+ * Allows the profile to alter the site configuration form.
+ */
+function pantheon_form_install_configure_form_alter(&$form, FormStateInterface $form_state) {
+  // Add a placeholder as example that one can choose an arbitrary site name.
+  $form['site_information']['site_name']['#attributes']['placeholder'] = t('My site');
+  $form['#submit'][] = 'pantheon_form_install_configure_submit';
+}
+
+/**
+ * Submission handler to sync the contact.form.feedback recipient.
+ */
+function pantheon_form_install_configure_submit($form, FormStateInterface $form_state) {
+  $site_mail = $form_state->getValue('site_mail');
+  ContactForm::load('feedback')->setRecipients([$site_mail])->trustData()->save();
+}


### PR DESCRIPTION
The installation profile in this PR, combined with the patch in https://www.drupal.org/node/2156401, will allow Drupal 8 to install cleanly on the Pantheon platform in 'git' mode (settings.php not modifiable).

Note that we have to duplicate a lot of stuff from the Standard profile.  There currently is no way for one profile to inherit from another; see https://www.drupal.org/node/1356276