### PR TITLE
Fixes #58. Include install.core.inc from settings.pantheon.php.

### DIFF
--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -46,6 +46,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
  *
  */
 if (isset($_ENV['PANTHEON_ENVIRONMENT']) && (substr($_SERVER['SCRIPT_NAME'],0,17) != '/core/install.php') && (!is_dir(__DIR__ . '/files/styles'))) {
+  include_once __DIR__ . '/../../core/includes/install.core.inc';
   include_once __DIR__ . '/../../core/includes/install.inc';
   install_goto('core/install.php');
 }


### PR DESCRIPTION
As mentioned in #58, we need to insure that install.core.inc is included as soon as we define $install_state; otherwise, the assumptions made by Drupal core are not maintained, and unpredictable things can happen.  This might get worse over time, resulting in other unpredictable problems.