### PR TITLE
Fixes #17:  Pre-select the 'standard' installation profile.

### DIFF
--- a/core/modules/system/system.install
+++ b/core/modules/system/system.install
@@ -36,7 +36,7 @@ function system_requirements($phase) {
 
     // Display the currently active installation profile, if the site
     // is not running the default installation profile.
-    $profile = (drupal_get_profile()) ? drupal_get_profile() : 'standard';
+    $profile = drupal_get_profile();
     if ($profile != 'standard') {
       $info = system_get_info('module', $profile);
       $requirements['install_profile'] = array(

--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -38,6 +38,18 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 
 /**
+ * Pre-select the 'standard' installation profile.  Drupal complains if we
+ * do not do this, and operational problems result.
+ *
+ * https://github.com/pantheon-systems/drops-8/issues/17
+ */
+if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+  // Pre-select the standard profile
+  $GLOBALS['install_state']['profile_info']['distribution']['name'] = 'standard';
+  $GLOBALS['install_state']['parameters']['profile'] = 'standard';
+}
+
+/**
  * Allow Drupal 8 to Cleanly Redirect to Install.php For New Sites.
  *
  * Issue: https://github.com/pantheon-systems/drops-8/issues/3


### PR DESCRIPTION
This also causes the installer to skip past the "select your installation profile" step.  I call this a "feature".  This may interfere with d8 installation profiles on Pantheon, but I figure that when we pre-package those, we can fix up these values in settings.php, after the inclusion of settings.pantheon.php.  Since these values are only needed during installation, it won't matter if the user removes them later.