### PR TITLE
Remove profile pre-selection

### DIFF
--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -38,18 +38,6 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 
 /**
- * Pre-select the 'standard' installation profile.  Drupal complains if we
- * do not do this, and operational problems result.
- *
- * https://github.com/pantheon-systems/drops-8/issues/17
- */
-if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  // Pre-select the standard profile
-  $GLOBALS['install_state']['profile_info']['distribution']['name'] = 'standard';
-  $GLOBALS['install_state']['parameters']['profile'] = 'standard';
-}
-
-/**
  * Allow Drupal 8 to Cleanly Redirect to Install.php For New Sites.
  *
  * Issue: https://github.com/pantheon-systems/drops-8/issues/3


### PR DESCRIPTION
Allow user to select their profile during installation again.

Pre-selecting the installation profile helped reduce problems during installation that could arise due to the [Schrödinger's Cache](https://github.com/pantheon-systems/drops-8/pull/61) bug. Now that we have fixed that problem, pre-selecting the profile is no longer necessary.  Drupal 8 installs cleanly with either the standard or minimal profile.