### PR TITLE
Set the install_state in the same code block as db settings

### DIFF
--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -27,17 +27,6 @@ else {
 }
 
 /**
- * Override the $install_state variable to let Drupal know that the settings are verified
- * since they are being passed directly by the Pantheon.
- *
- * Issue: https://github.com/pantheon-systems/drops-8/issues/9
- *
- */
-if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  $GLOBALS['install_state']['settings_verified'] = TRUE;
-}
-
-/**
  * Pre-select the 'standard' installation profile.  Drupal complains if we
  * do not do this, and operational problems result.
  *
@@ -87,6 +76,14 @@ if (isset($_SERVER['PRESSFLOW_SETTINGS'])) {
         $databases = array();
       }
       $databases = array_replace_recursive($databases, $value);
+
+      // During installation, override the $install_state variable to
+      // let Drupal know that the settings are verified since they are
+      // being passed directly by the Pantheon.
+      // Issue: https://github.com/pantheon-systems/drops-8/issues/9
+      if (substr($_SERVER['SCRIPT_NAME'],0,17) == '/core/install.php') {
+        $GLOBALS['install_state']['settings_verified'] = TRUE;
+      }
     }
     else {
       $$key = $value;


### PR DESCRIPTION
The code in this PR is functionally equivalent to what is already committed; however, it makes a little more sense to set the install_state variable at the same point in settings.pantheon.php where the database variable is expanded, because these two settings go hand-in-hand:  if the database variable is set, then we should not ask the user to provide database credentials at installation time.  Having this code together allows it to be read / inspected together, and would help if this code was ever migrated somewhere else (c.f. #56).

This PR also insures that the install_state is only set during installation, preventing spurious global settings on other pages (which should always ignore this variable in any event).