### PR TITLE
Fixes #73: Remove 'active' configuration store

### DIFF
--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -18,13 +18,11 @@ $is_installer_url = (strpos($_SERVER['SCRIPT_NAME'], '/core/install.php') === 0)
  */
 if ($is_installer_url) {
   $config_directories = array(
-    CONFIG_ACTIVE_DIRECTORY => 'sites/default/files',
     CONFIG_STAGING_DIRECTORY => 'sites/default/files',
   );
 }
 else {
   $config_directories = array(
-    CONFIG_ACTIVE_DIRECTORY => 'sites/default/files/config/active',
     CONFIG_STAGING_DIRECTORY => 'sites/default/config',
   );
 }


### PR DESCRIPTION
This is no longer part of Drupal 8 as of beta16.

This PR should only be used with beta16 or later; it causes problems with earlier version of Drupal.