### PR TITLE
Remove 'cache' directories from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,15 +3,18 @@ sites/*/files
 sites/*/private
 files/*
 private/*
-cache
 
 # Pantheon commits a settings.php for environment-specific settings.
 # Place local settings in settings.local.php
 sites/*/settings.local.php
+sites/*/services*.yml
 
 # ** Only works in OSs that support newer versions of fnmatch (Bash 4+)
 /sites/default/**/files
 /sites/default/**/private
+
+# Ignore SimpleTest multi-site environment.
+sites/simpletest
 
 # Packages #
 ############


### PR DESCRIPTION
Drupal 8 commits some directories with this name. Excluding these in .gitignore can make it difficult to merge in all of the needed files in a Drupal update.

Removing this so far has not resulted in any large change sets. If anything shows up, perhaps we can put in a more specific ignore path.