### PR TITLE
Update to Drupal 8.0.0.

### DIFF
--- a/core/CHANGELOG.txt
+++ b/core/CHANGELOG.txt
@@ -1,8 +1,9 @@
-Drupal 8.0.x, xxxx-xx-xx (development version)
-----------------------
-- Dramatically improved the front end:
+Drupal 8.0.0, 2015-11-19
+------------------------
+- Significantly improved the front end:
     * Made all built-in themes responsive.
     * Added support for responsive images.
+    * Made built-in tables responsive with three levels of column importance.
     * Added Twig as the default template engine and converted all .tpl.php
       templates and theme functions to .html.twig.
     * Removed the PHPTemplate engine.
@@ -10,17 +11,16 @@ Drupal 8.0.x, xxxx-xx-xx (development version)
     * Added Classy as a base theme to maintain CSS classes and wrappers.
     * Added Stable as the default base theme to maintain backwards compatibility
       for core template and CSS changes, because templates and CSS outside
-      Stable can be improved in minor releases (8.1.0, 8.2.0 …).
+      Stable can be improved in minor releases (8.1.0, 8.2.0, etc.).
     * Redesigned several key elements of the Seven theme.
     * Added support for HTML5 elements.
-    * Included the HTML5 Shiv library to support HTML5 elements in IE 8 and
-      below.
     * Included Backbone.js and Underscore.js JavaScript frameworks.
     * Updated to jQuery 2.1.4.
     * Updated to jQuery UI 1.11.4.
     * Removed jquery.bbq.
     * Removed the Garland theme from core.
-    * Removed the Overlay module from core.
+    * Removed the Overlay module from core and replaced it with a simple,
+      dynamic "Back to site" link.
     * Improved the asset library system to manage CSS and JavaScript files and
       their dependencies. Allowing for smaller AJAX request payloads.
     * jQuery is no longer loaded on all pages, only when another asset needs it.
@@ -29,41 +29,72 @@ Drupal 8.0.x, xxxx-xx-xx (development version)
     * Implemented SMACSS-style categorization for CSS files.
     * Removed most support for Internet Explorer 8 and below.
     * Added Modernizr for making styling changes based on browser support.
-    * All page template variables converted to blocks.
-- Added tour module. Provides highly contextual tips for UI elements.
-- Improved entity system.
-    * Added support for saving and deleting entities through the controller.
-    * Base entity fields (such as labels) support widgets, formatters and
-      translation.
-    * Form modes introduced, similar to display modes.
-    * Entities are now classed objects, implementing EntityInterface.
-    * Drupal now understands the concept of a "default" revision, tracked
-      independently from the latest revision, allowing for the creation of
-      drafts while the current revision stays published.
-    * All entity types, not just nodes, now have support for revisions.
+    * All page template variables converted to blocks (title, breadcrumb,
+      branding, etc).
+    * Added the Breakpoint module to manage breakpoints of responsive designs.
+    * Introduced native Schema.org output in pages.
+    * Made use of semantic HTML 5 tags when possible. This also makes form input
+      on mobile devices much easier for users.
+    * Redesigned icons to look good on high resolution (retina) displays too.
+- Made the site administration experience simpler:
+    * Redesigned the installer.
+    * Visually updated and extended the Seven (administration) theme.
+    * Made the administration toolbar responsive and touch friendly.
+    * Added search to the module listing and made the page easier to read.
+    * Added the tour module to provide highly contextual tips for UI elements.
+- Improved the entity system:
+    * Added a full CRUD API for entities.
+    * Improved the field API and entity query API.
+    * Added support for widgets, formatters, and translation to base entity
+      fields (such as labels).
+    * Made view modes configurable for reusable display variants.
+    * Introduced form modes for reusable form variants.
+    * Added ability to handle a "default" revision that may not be the latest.
+    * All content entity types (custom blocks, terms, comments, etc.), not just
+      nodes, have support for revisions.
+    * Database schema of content entities is automatically generated based on
+      entity type and field definitions.
+- Added the Typed Data system to manage complex types.
 - Refactored routing system based on Symfony2 components.
-- Reworked menu links, local actions, and local tasks based upon the new routing
-  system.
+- Made declarative information (libraries, permissions, routes etc.) use YAML
+  files for definitions instead of PHP.
+- Improved the menu handling systems:
+    * Moved custom menu item handling to its own module.
+    * Reworked menu links, local actions, and local tasks based upon the new
+      routing system.
 - Added plugin system to standardize implementation of several core APIs.
-- Configuration:
-    * Added a centralized file-based configuration system.
-    * Allows module authors to provide configuration in a standard format.
-    * Implements functionality to get, set, add and remove configuration.
-    * Includes ability to override configuration values with language variants
-      and other runtime values.
-    * Supports configuration schema, dependencies, and validation to maintain
-      data-integrity between deployments and updates.
+- Introduced a new configuration management system:
+    * Added a centralized configuration system with export and import
+      functionality.
+    * Allowed module authors to provide configuration in a YAML file format.
+    * Implemented functionality to get, set, add, and remove configuration.
+    * Provided the ability to override configuration values with language
+      variants and other runtime values.
+    * Added configuration schema, dependencies, and validation to maintain
+      data integrity between deployments and updates.
+    * Support added for both global configuration and configuration entities.
 - Improved authoring experience:
+    * Redesigned the content creation and editing form.
+    * Content preview is now displayed on the frontend.
     * Added the CKEditor WYSIWYG editor. Clean markup guaranteed thanks to tight
       integration with the filter system.
-    * Includes uploading, aligning and captioning of images.
-    * Correspondingly modernized the default text formats.
-    * Provides a drag-and-drop configuration UI, which automatically updates the
+    * Made uploading, aligning, and captioning of images possible in the editor.
+    * Modernized the default text formats.
+    * Added a drag-and-drop configuration UI, which automatically updates the
       HTML filter settings, making configuring text formats trivial for typical
       use cases.
     * Added align and caption filters that can be applied to any element:
       images, blockquotes, code snippets, videos…
-    * In-place editing of any entity: nodes, blocks…
+    * Made possible to in-place edit any entity: nodes, blocks…
+    * Added the Text Editor module to help map other editors to text formats.
+- Improved media management:
+    * Added ability to configure when unused files get deleted with the option
+      to keep them, useful for media libraries.
+    * Added a customizable view under the content administration screen that
+      lists all files uploaded on the system.
+    * Made uploads immediate when selecting files in file fields.
+    * Added ability to upload multiple files at once.
+    * Added local image input filter, to enable secure image posting.
 - Included the following Symfony2 components:
     * ClassLoader - PSR-0-compatible autoload routines.
     * DependencyInjection - Flexible dependency injection container.
@@ -86,16 +117,14 @@ Drupal 8.0.x, xxxx-xx-xx (development version)
       * Blog
       * Dashboard
       * OpenID
-      * PHP Filter
       * Poll
       * Profile
       * Trigger
-- Removed the Statistics module's accesslog functionality and reports from core.
+- Removed the Statistics module's accesslog functionality and reports.
 - Removed XML-RPC functionality from core.
 - Removed user signatures support from core.
-- Universally Unique IDentifier (UUID):
-    * Support for generating and validating UUIDs.
-- Tremendously improved language support all around.
+- Added ability to generate and validate Universally Unique IDentifiers (UUIDs).
+- Tremendously improved language support all around:
     * Great language improvements for users:
       * Improved language selection with user preference detection in the
         installer based on browser settings.
@@ -143,12 +172,6 @@ Drupal 8.0.x, xxxx-xx-xx (development version)
         configuration with translatable values (blocks, views, fields, etc.).
       * Added language options to block visibility.
     * Much improved language APIs for developers:
-      * Added simple APIs and hooks to save/delete/update languages.
-      * New Language class wraps language information, used universally.
-      * Unified database schemas and APIs to make it easier to spot where
-        language codes are referenced.
-      * Made the language negotiation system APIs more consistent for
-        developers.
       * Made it possible for users to have a preferred language separate from
         their user entity language.
       * The text formatter from t() is now available as FormattableMarkup.
@@ -157,49 +180,54 @@ Drupal 8.0.x, xxxx-xx-xx (development version)
         menu items and contextual links.
       * Removed textgroups support from interface translation in favor of
         native configuration language support.
-      * Added configuration schema system to support generating translation
-        forms for any configuration.
-      * Reworked Gettext PO support to use pluggable read/write handlers.
-      * Added language select form element in the Form API.
       * Added a transliteration API. (Only used for machine names in core.)
+      * Added a language fallback capability to the interface translation API.
 - New field types added to core:
-  - Email
-  - Link
-  - Phone number
-  - Entity reference
-  - Date
-  - Comment (allows comment threads on entity types other than node).
-- Added local image input filter, to enable secure image posting.
+    * Email
+    * Link
+    * Telephone number
+    * Entity reference
+    * Date
+- Made commenting more flexible:
+    * Added the notion of comment types (for reviews, greetings, and so on),
+      each of which can be configured with a different set of fields.
+    * Made commenting a field to allow comment threads on entity types other
+      than nodes.
 - Added Views and Views UI module to core:
-  * Various core listings: /node, /admin/content/node, /admin/people etc. are
-    now served by views.
-  * REST API support built in.
-  * Rewrote caching integration for better performance.
-- Custom blocks are now fieldable, revisionable, and translatable entities.
-- An accessible modal API based on improvements made in collaboration with the
-  jQuery UI team and the Views team.
-- Fieldable contact forms allowing site-builders to easily build custom forms
-  for soliciting feedback from users.
+    * Added simple bulk operations functionality to Views.
+    * Converted various core listings to views, including /node,
+      /admin/content/node, /admin/people, and several blocks.
+    * Built in REST API support.
+    * Rewrote caching integration for better performance.
+    * Made it possible to configure responsive tables in Views.
+- Greatly improved block management:
+    * Made custom blocks fieldable, revisionable, and translatable entities.
+    * Added the notion of custom block types.
+    * Added the ability to place the same block in multiple locations.
+    * Introduced a block library with categorized blocks.
+- Introduced an accessible modal API based on improvements made in collaboration
+  with the jQuery UI team.
+- Made it possible to add fields to contact forms allowing site-builders to
+  easily build custom forms for soliciting feedback from users.
 - Added a Web Services module package.
     * Added a RESTful web services provider module.
     * Added a serialization module using the Symfony serialization component.
     * Added a Hypertext Application Language (HAL) serialization module.
     * Added a HTTP Basic authentication provider module.
-- Significant performance/scalability improvements:
- * Cache tags, which allow content to be invalidated accurately and instantly,
-   including reverse proxies and CDNs.
- * Cache contexts, which allow content to be cached correctly, and placeholdered
-   to improve cache hit rates.
- * Cacheability bubbling, which allows strict tracking of assets and
-   cacheability throughout page rendering.
- * Page caching has been factored out to its own module and is enabled by
-   default.
- * Authenticated page caching has been added to core via the Dynamic Page Cache
-   module and is enabled by default.
- * APCu, memory, and PHP file caching backends added to core, alongside support
-   for a chained, consistent cache backend to support correctly using fast
-   local cache implementations with multiple web servers.
-- When using MySQL, the MyISAM engine is no longer supported.
+- Improved performance/scalability significantly:
+    * Introduced cache tags, which allow content to be invalidated accurately
+      and instantly, including for reverse proxies and CDNs.
+    * Added cache contexts, which allow content to be cached correctly, and
+      placeholdered to improve cache hit rates.
+    * Implemented cacheability bubbling, which allows strict tracking of assets
+      and cacheability throughout page rendering.
+    * Factored out page caching to its own module and enabled it by default.
+    * Added the Dynamic Page Cache module for authenticated page caching and
+      enabled it by default.
+    * Added APCu, memory, and PHP file caching backends to core, alongside
+      support for a chained, consistent cache backend to support correctly using
+      fast local cache implementations with multiple web servers.
+- Removed support for MyISAM, when using MySQL.
 - Testing improvements
     * Added PHPUnit for proper unit testing, see
       https://phpunit.de/manual/4.8/en/index.html so you can run tests via
@@ -209,6 +237,32 @@ Drupal 8.0.x, xxxx-xx-xx (development version)
     * Added KernelTestBase to provide a fast API testing of integration of
       different components
     * Core branch nightly tests include PHP 5.5, 5.6, 7, sqlite and PostgreSQL.
+- Added the migrate module (experimental) with support for migrating content and
+  configuration from earlier Drupal versions.
+- Introduced support for Composer.
+- Moved the automated cron execution functionality to its own module.
+- Refactored IP address based banning functionality to its own module.
+- Security improvements:
+    * Removed PHP filter, including the ability to use PHP for block visibility.
+    * Managing fields for each entity type is now a separate permission.
+    * PDO drivers other than MySQL are now limited to executing single
+      statements to limit SQL injection vectors.
+    * Added an autoescape API to prevent cross-site scripting in many of the
+      places where Drupal outputs HTML.
+    * Hardened user session and session ID handling.
+    * Automated CSRF protection in route definitions.
+    * Clickjacking protection enabled by default.
+    * Made the core JavaScript API compatible with Content Security Policy
+      (CSP).
+    * Trusted host patterns enforced for requests preventing cache and link
+      poisoning.
+- Switched to semantic versioning with significant updates planned every 6
+  months in 8.1, 8.2, etc.
+- Numerous other important changes and additions. See
+  https://www.drupal.org/list-changes/drupal for a detailed list.
+- Numerous bug fixes.
+- Numerous API documentation improvements.
+- Additional automated test coverage.
 
 Drupal 7.0, 2011-01-05
 ----------------------

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.0.0-dev-2015-11-17';
+  const VERSION = '8.0.0';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Config/ConfigImporter.php
+++ b/core/lib/Drupal/Core/Config/ConfigImporter.php
@@ -511,8 +511,6 @@ class ConfigImporter {
    *   If the configuration is already importing.
    */
   public function initialize() {
-    $this->createExtensionChangelist();
-
     // Ensure that the changes have been validated.
     $this->validate();
 
@@ -710,8 +708,10 @@ class ConfigImporter {
    * @throws \Drupal\Core\Config\ConfigImporterException
    *   Exception thrown if the validate event logged any errors.
    */
-  protected function validate() {
+  public function validate() {
     if (!$this->validated) {
+      // Create the list of installs and uninstalls.
+      $this->createExtensionChangelist();
       // Validate renames.
       foreach ($this->getUnprocessedConfiguration('rename') as $name) {
         $names = $this->storageComparer->extractRenameNames($name);

--- a/core/lib/Drupal/Core/Config/Entity/ConfigEntityType.php
+++ b/core/lib/Drupal/Core/Config/Entity/ConfigEntityType.php
@@ -69,9 +69,6 @@ class ConfigEntityType extends EntityType implements ConfigEntityTypeInterface {
     // Always add a default 'uuid' key.
     $this->entity_keys['uuid'] = 'uuid';
     $this->entity_keys['langcode'] = 'langcode';
-    if (isset($this->handlers['storage'])) {
-      $this->checkStorageClass($this->handlers['storage']);
-    }
     $this->handlers += array(
       'storage' => 'Drupal\Core\Config\Entity\ConfigEntityStorage',
     );
@@ -135,22 +132,11 @@ class ConfigEntityType extends EntityType implements ConfigEntityTypeInterface {
   /**
    * {@inheritdoc}
    *
+   * @see \Drupal\Core\Config\Entity\ConfigEntityStorage.
+   *
    * @throws \Drupal\Core\Config\Entity\Exception\ConfigEntityStorageClassException
    *   Exception thrown when the provided class is not an instance of
    *   \Drupal\Core\Config\Entity\ConfigEntityStorage.
-   */
-  public function setStorageClass($class) {
-    $this->checkStorageClass($class);
-    parent::setStorageClass($class);
-  }
-
-  /**
-   * Checks that the provided class is an instance of ConfigEntityStorage.
-   *
-   * @param string $class
-   *   The class to check.
-   *
-   * @see \Drupal\Core\Config\Entity\ConfigEntityStorage.
    */
   protected function checkStorageClass($class) {
     if (!is_a($class, 'Drupal\Core\Config\Entity\ConfigEntityStorage', TRUE)) {

--- a/core/lib/Drupal/Core/Entity/ContentEntityBase.php
+++ b/core/lib/Drupal/Core/Entity/ContentEntityBase.php
@@ -811,6 +811,13 @@ abstract class ContentEntityBase extends Entity implements \IteratorAggregate, C
   /**
    * {@inheritdoc}
    */
+  public function isNewTranslation() {
+    return $this->translations[$this->activeLangcode]['status'] == static::TRANSLATION_CREATED;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function addTranslation($langcode, array $values = array()) {
     // Make sure we do not attempt to create a translation if an invalid
     // language is specified or the entity cannot be translated.
@@ -822,37 +829,11 @@ abstract class ContentEntityBase extends Entity implements \IteratorAggregate, C
       throw new \InvalidArgumentException("The entity cannot be translated since it is language neutral ({$this->defaultLangcode}).");
     }
 
-    // Instantiate a new empty entity so default values will be populated in the
-    // specified language.
-    $entity_type = $this->getEntityType();
-
-    $default_values = array(
-      $entity_type->getKey('bundle') => $this->bundle(),
-      $this->langcodeKey => $langcode,
-    );
-    $entity = $this->entityManager()
-      ->getStorage($this->getEntityTypeId())
-      ->create($default_values);
-
-    foreach ($entity as $name => $field) {
-      if (!isset($values[$name]) && !$field->isEmpty()) {
-        $values[$name] = $field->getValue();
-      }
-    }
-    $values[$this->langcodeKey] = $langcode;
-    $values[$this->defaultLangcodeKey] = FALSE;
-
+    // Initialize the translation object.
+    /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
+    $storage = $this->entityManager()->getStorage($this->getEntityTypeId());
     $this->translations[$langcode]['status'] = static::TRANSLATION_CREATED;
-    $translation = $this->getTranslation($langcode);
-    $definitions = $translation->getFieldDefinitions();
-
-    foreach ($values as $name => $value) {
-      if (isset($definitions[$name]) && $definitions[$name]->isTranslatable()) {
-        $translation->values[$name][$langcode] = $value;
-      }
-    }
-
-    return $translation;
+    return $storage->createTranslation($this, $langcode, $values);
   }
 
   /**

--- a/core/lib/Drupal/Core/Entity/ContentEntityStorageInterface.php
+++ b/core/lib/Drupal/Core/Entity/ContentEntityStorageInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Core\Entity\ContentEntityStorageInterface.
+ */
+
+namespace Drupal\Core\Entity;
+
+/**
+ * A storage that supports content entity types.
+ */
+interface ContentEntityStorageInterface extends EntityStorageInterface {
+
+  /**
+   * Constructs a new entity translation object, without permanently saving it.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *   The entity object being translated.
+   * @param string $langcode
+   *   The translation language code.
+   * @param array $values
+   *   (optional) An associative array of initial field values keyed by field
+   *   name. If none is provided default values will be applied.
+   *
+   * @return \Drupal\Core\Entity\ContentEntityInterface
+   *   A new entity translation object.
+   */
+  public function createTranslation(ContentEntityInterface $entity, $langcode, array $values = []);
+
+}

--- a/core/lib/Drupal/Core/Entity/ContentEntityType.php
+++ b/core/lib/Drupal/Core/Entity/ContentEntityType.php
@@ -30,4 +30,20 @@ class ContentEntityType extends EntityType implements ContentEntityTypeInterface
     return 'content';
   }
 
+  /**
+   * {@inheritdoc}
+   *
+   * @see \Drupal\Core\Entity\ContentEntityStorageInterface.
+   *
+   * @throws \InvalidArgumentException
+   *   If the provided class does not implement
+   *   \Drupal\Core\Entity\ContentEntityStorageInterface.
+   */
+  protected function checkStorageClass($class) {
+    $required_interface = ContentEntityStorageInterface::class;
+    if (!is_subclass_of($class, $required_interface)) {
+      throw new \InvalidArgumentException("$class does not implement $required_interface");
+    }
+  }
+
 }

--- a/core/lib/Drupal/Core/Entity/EntityType.php
+++ b/core/lib/Drupal/Core/Entity/EntityType.php
@@ -276,6 +276,9 @@ class EntityType implements EntityTypeInterface {
     $this->handlers += array(
       'access' => 'Drupal\Core\Entity\EntityAccessControlHandler',
     );
+    if (isset($this->handlers['storage'])) {
+      $this->checkStorageClass($this->handlers['storage']);
+    }
 
     // Automatically add the EntityChanged constraint if the entity type tracks
     // the changed time.
@@ -459,7 +462,18 @@ class EntityType implements EntityTypeInterface {
    * {@inheritdoc}
    */
   public function setStorageClass($class) {
+    $this->checkStorageClass($class);
     $this->handlers['storage'] = $class;
+  }
+
+  /**
+   * Checks that the provided class is an instance of ConfigEntityStorage.
+   *
+   * @param string $class
+   *   The class to check.
+   */
+  protected function checkStorageClass($class) {
+    // Nothing to check by default.
   }
 
   /**

--- a/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueContentEntityStorage.php
+++ b/core/lib/Drupal/Core/Entity/KeyValueStore/KeyValueContentEntityStorage.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\Core\Entity\KeyValueStore\KeyValueContentEntityStorage.
+ */
+
+namespace Drupal\Core\Entity\KeyValueStore;
+
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
+
+/**
+ * Provides a key value backend for content entities.
+ */
+class KeyValueContentEntityStorage extends KeyValueEntityStorage implements ContentEntityStorageInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createTranslation(ContentEntityInterface $entity, $langcode, array $values = []) {
+    // @todo
+  }
+
+}

--- a/core/lib/Drupal/Core/Entity/entity.api.php
+++ b/core/lib/Drupal/Core/Entity/entity.api.php
@@ -780,10 +780,9 @@ function hook_entity_bundle_delete($entity_type_id, $bundle) {
 }
 
 /**
- * Act on a newly created entity.
+ * Acts when creating a new entity.
  *
- * This hook runs after a new entity object has just been instantiated. It can
- * be used to set initial values, e.g. to provide defaults.
+ * This hook runs after a new entity object has just been instantiated.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The entity object.
@@ -792,16 +791,13 @@ function hook_entity_bundle_delete($entity_type_id, $bundle) {
  * @see hook_ENTITY_TYPE_create()
  */
 function hook_entity_create(\Drupal\Core\Entity\EntityInterface $entity) {
-  if ($entity instanceof FieldableEntityInterface && !$entity->foo->value) {
-    $entity->foo->value = 'some_initial_value';
-  }
+  \Drupal::logger('example')->info('Entity created: @label', ['@label' => $entity->label()]);
 }
 
 /**
- * Act on a newly created entity of a specific type.
+ * Acts when creating a new entity of a specific type.
  *
- * This hook runs after a new entity object has just been instantiated. It can
- * be used to set initial values, e.g. to provide defaults.
+ * This hook runs after a new entity object has just been instantiated.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The entity object.
@@ -810,9 +806,7 @@ function hook_entity_create(\Drupal\Core\Entity\EntityInterface $entity) {
  * @see hook_entity_create()
  */
 function hook_ENTITY_TYPE_create(\Drupal\Core\Entity\EntityInterface $entity) {
-  if (!$entity->foo->value) {
-    $entity->foo->value = 'some_initial_value';
-  }
+  \Drupal::logger('example')->info('ENTITY_TYPE created: @label', ['@label' => $entity->label()]);
 }
 
 /**
@@ -1009,6 +1003,38 @@ function hook_ENTITY_TYPE_update(Drupal\Core\Entity\EntityInterface $entity) {
     ))
     ->condition('id', $entity->id())
     ->execute();
+}
+
+/**
+ * Acts when creating a new entity translation.
+ *
+ * This hook runs after a new entity translation object has just been
+ * instantiated.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $translation
+ *   The entity object.
+ *
+ * @ingroup entity_crud
+ * @see hook_ENTITY_TYPE_translation_create()
+ */
+function hook_entity_translation_create(\Drupal\Core\Entity\EntityInterface $translation) {
+  \Drupal::logger('example')->info('Entity translation created: @label', ['@label' => $translation->label()]);
+}
+
+/**
+ * Acts when creating a new entity translation of a specific type.
+ *
+ * This hook runs after a new entity translation object has just been
+ * instantiated.
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $translation
+ *   The entity object.
+ *
+ * @ingroup entity_crud
+ * @see hook_entity_translation_create()
+ */
+function hook_ENTITY_TYPE_translation_create(\Drupal\Core\Entity\EntityInterface $translation) {
+  \Drupal::logger('example')->info('ENTITY_TYPE translation created: @label', ['@label' => $translation->label()]);
 }
 
 /**
@@ -1883,6 +1909,44 @@ function hook_entity_field_access_alter(array &$grants, array $context) {
     // AccessResultInterface::isAllowed() , because the grants of other modules
     // should still decide on their own if this field is accessible or not
     $grants['node'] = AccessResult::neutral()->inheritCacheability($grants['node']);
+  }
+}
+
+/**
+ * Acts when initializing a fieldable entity object.
+ *
+ * This hook runs after a new entity object or a new entity translation object
+ * has just been instantiated. It can be used to set initial values, e.g. to
+ * provide defaults.
+ *
+ * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+ *   The entity object.
+ *
+ * @ingroup entity_crud
+ * @see hook_ENTITY_TYPE_field_values_init()
+ */
+function hook_entity_field_values_init(\Drupal\Core\Entity\FieldableEntityInterface $entity) {
+  if ($entity instanceof \Drupal\Core\Entity\ContentEntityInterface && !$entity->foo->value) {
+    $entity->foo->value = 'some_initial_value';
+  }
+}
+
+/**
+ * Acts when initializing a fieldable entity object.
+ *
+ * This hook runs after a new entity object or a new entity translation object
+ * has just been instantiated. It can be used to set initial values, e.g. to
+ * provide defaults.
+ *
+ * @param \Drupal\Core\Entity\FieldableEntityInterface $entity
+ *   The entity object.
+ *
+ * @ingroup entity_crud
+ * @see hook_entity_field_values_init()
+ */
+function hook_ENTITY_TYPE_field_values_init(\Drupal\Core\Entity\FieldableEntityInterface $entity) {
+  if (!$entity->foo->value) {
+    $entity->foo->value = 'some_initial_value';
   }
 }
 

--- a/core/lib/Drupal/Core/TypedData/TranslatableInterface.php
+++ b/core/lib/Drupal/Core/TypedData/TranslatableInterface.php
@@ -29,6 +29,14 @@ interface TranslatableInterface {
   public function isDefaultTranslation();
 
   /**
+   * Checks whether the translation is new.
+   *
+   * @return bool
+   *   TRUE if the translation is new, FALSE otherwise.
+   */
+  public function isNewTranslation();
+
+  /**
    * Returns the languages the data is translated to.
    *
    * @param bool $include_default

--- a/core/modules/aggregator/src/FeedStorageInterface.php
+++ b/core/modules/aggregator/src/FeedStorageInterface.php
@@ -7,12 +7,12 @@
 
 namespace Drupal\aggregator;
 
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 
 /**
  * Defines an interface for aggregator feed entity storage classes.
  */
-interface FeedStorageInterface extends EntityStorageInterface {
+interface FeedStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Returns the fids of feeds that need to be refreshed.

--- a/core/modules/aggregator/src/ItemStorageInterface.php
+++ b/core/modules/aggregator/src/ItemStorageInterface.php
@@ -7,12 +7,12 @@
 
 namespace Drupal\aggregator;
 
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 
 /**
  * Defines an interface for aggregator item entity storage classes.
  */
-interface ItemStorageInterface extends EntityStorageInterface {
+interface ItemStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Returns the count of the items in a feed.

--- a/core/modules/block_content/src/BlockContentViewsData.php
+++ b/core/modules/block_content/src/BlockContentViewsData.php
@@ -36,25 +36,24 @@ class BlockContentViewsData extends EntityViewsData {
       ),
     );
     // Advertise this table as a possible base table.
-    $data['block_content_revision']['table']['base']['help'] = $this->t('Block Content revision is a history of changes to block content.');
-    $data['block_content_revision']['table']['base']['defaults']['title'] = 'info';
+    $data['block_content_field_revision']['table']['base']['help'] = $this->t('Block Content revision is a history of changes to block content.');
+    $data['block_content_field_revision']['table']['base']['defaults']['title'] = 'info';
 
     // @todo EntityViewsData should add these relationships by default.
     //   https://www.drupal.org/node/2410275
-    $data['block_content_revision']['id']['relationship']['id'] = 'standard';
-    $data['block_content_revision']['id']['relationship']['base'] = 'block_content';
-    $data['block_content_revision']['id']['relationship']['base field'] = 'id';
-    $data['block_content_revision']['id']['relationship']['title'] = $this->t('Block Content');
-    $data['block_content_revision']['id']['relationship']['label'] = $this->t('Get the actual block content from a block content revision.');
+    $data['block_content_field_revision']['id']['relationship']['id'] = 'standard';
+    $data['block_content_field_revision']['id']['relationship']['base'] = 'block_content_field_data';
+    $data['block_content_field_revision']['id']['relationship']['base field'] = 'id';
+    $data['block_content_field_revision']['id']['relationship']['title'] = $this->t('Block Content');
+    $data['block_content_field_revision']['id']['relationship']['label'] = $this->t('Get the actual block content from a block content revision.');
 
-    $data['block_content_revision']['revision_id']['relationship']['id'] = 'standard';
-    $data['block_content_revision']['revision_id']['relationship']['base'] = 'block_content';
-    $data['block_content_revision']['revision_id']['relationship']['base field'] = 'revision_id';
-    $data['block_content_revision']['revision_id']['relationship']['title'] = $this->t('Block Content');
-    $data['block_content_revision']['revision_id']['relationship']['label'] = $this->t('Get the actual block content from a block content revision.');
+    $data['block_content_field_revision']['revision_id']['relationship']['id'] = 'standard';
+    $data['block_content_field_revision']['revision_id']['relationship']['base'] = 'block_content_field_data';
+    $data['block_content_field_revision']['revision_id']['relationship']['base field'] = 'revision_id';
+    $data['block_content_field_revision']['revision_id']['relationship']['title'] = $this->t('Block Content');
+    $data['block_content_field_revision']['revision_id']['relationship']['label'] = $this->t('Get the actual block content from a block content revision.');
 
     return $data;
-
   }
 
 }

--- a/core/modules/block_content/src/Tests/Views/RevisionRelationshipsTest.php
+++ b/core/modules/block_content/src/Tests/Views/RevisionRelationshipsTest.php
@@ -60,7 +60,7 @@ class RevisionRelationshipsTest extends ViewTestBase {
     $column_map = array(
       'revision_id' => 'revision_id',
       'id_1' => 'id_1',
-      'block_content_block_content_revision_id' => 'block_content_block_content_revision_id',
+      'block_content_field_data_block_content_field_revision_id' => 'block_content_field_data_block_content_field_revision_id',
     );
 
     // Here should be two rows.
@@ -70,12 +70,12 @@ class RevisionRelationshipsTest extends ViewTestBase {
       array(
         'revision_id' => '1',
         'id_1' => '1',
-        'block_content_block_content_revision_id' => '1',
+        'block_content_field_data_block_content_field_revision_id' => '1',
       ),
       array(
         'revision_id' => '2',
         'id_1' => '1',
-        'block_content_block_content_revision_id' => '1',
+        'block_content_field_data_block_content_field_revision_id' => '1',
       ),
     );
     $this->assertIdenticalResultset($view_id, $resultset_id, $column_map);
@@ -87,7 +87,7 @@ class RevisionRelationshipsTest extends ViewTestBase {
       array(
         'revision_id' => '2',
         'id_1' => '1',
-        'block_content_block_content_revision_id' => '1',
+        'block_content_field_data_block_content_field_revision_id' => '1',
       ),
     );
     $this->assertIdenticalResultset($view_revision_id, $resultset_revision_id, $column_map);

--- a/core/modules/block_content/tests/modules/block_content_test_views/test_views/views.view.test_block_content_revision_id.yml
+++ b/core/modules/block_content/tests/modules/block_content_test_views/test_views/views.view.test_block_content_revision_id.yml
@@ -8,7 +8,7 @@ label: null
 module: views
 description: ''
 tag: ''
-base_table: block_content_revision
+base_table: block_content_field_revision
 base_field: revision_id
 core: '8'
 display:
@@ -17,28 +17,28 @@ display:
       relationships:
         id:
           id: id
-          table: block_content_revision
+          table: block_content_field_revision
           field: id
           required: true
           plugin_id: standard
       fields:
         revision_id:
           id: revision_id
-          table: block_content_revision
+          table: block_content_field_revision
           field: revision_id
           plugin_id: field
           entity_type: block_content
           entity_field: revision_id
         id_1:
           id: id_1
-          table: block_content_revision
+          table: block_content_field_revision
           field: id
           plugin_id: field
           entity_type: block_content
           entity_field: id
         id:
           id: id
-          table: block_content
+          table: block_content_field_data
           field: id
           relationship: id
           plugin_id: field
@@ -47,11 +47,20 @@ display:
       arguments:
         id:
           id: id
-          table: block_content_revision
+          table: block_content_field_revision
           field: id
           plugin_id: numeric
           entity_type: block_content
           entity_field: id
+      sorts:
+        revision_id:
+          id: revision_id
+          table: block_content_field_revision
+          field: revision_id
+          order: ASC
+          plugin_id: field
+          entity_type: block_content
+          entity_field: revision_id
     display_plugin: default
     display_title: Master
     id: default

--- a/core/modules/block_content/tests/modules/block_content_test_views/test_views/views.view.test_block_content_revision_revision_id.yml
+++ b/core/modules/block_content/tests/modules/block_content_test_views/test_views/views.view.test_block_content_revision_revision_id.yml
@@ -8,7 +8,7 @@ label: null
 module: views
 description: ''
 tag: ''
-base_table: block_content_revision
+base_table: block_content_field_revision
 base_field: revision_id
 core: '8'
 display:
@@ -17,7 +17,7 @@ display:
       relationships:
         revision_id:
           id: revision_id
-          table: block_content_revision
+          table: block_content_field_revision
           field: revision_id
           required: true
           entity_type: block_content
@@ -26,21 +26,21 @@ display:
       fields:
         revision_id:
           id: revision_id
-          table: block_content_revision
+          table: block_content_field_revision
           field: revision_id
           plugin_id: field
           entity_type: block_content
           entity_field: revision_id
         id_1:
           id: id_1
-          table: block_content_revision
+          table: block_content_field_revision
           field: id
           plugin_id: field
           entity_type: block_content
           entity_field: id
         id:
           id: id
-          table: block_content
+          table: block_content_field_data
           field: id
           relationship: revision_id
           plugin_id: field
@@ -49,11 +49,20 @@ display:
       arguments:
         id:
           id: id
-          table: block_content_revision
+          table: block_content_field_revision
           field: id
           plugin_id: block_content_id
           entity_type: block_content
           entity_field: id
+      sorts:
+        revision_id:
+          id: revision_id
+          table: block_content_field_revision
+          field: revision_id
+          order: ASC
+          plugin_id: field
+          entity_type: block_content
+          entity_field: revision_id
       display_extenders: {  }
     display_plugin: default
     display_title: Master

--- a/core/modules/comment/src/CommentStorageInterface.php
+++ b/core/modules/comment/src/CommentStorageInterface.php
@@ -8,13 +8,13 @@
 namespace Drupal\comment;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 use Drupal\Core\Entity\FieldableEntityInterface;
 
 /**
  * Defines an interface for comment entity storage classes.
  */
-interface CommentStorageInterface extends EntityStorageInterface {
+interface CommentStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Gets the maximum encoded thread value for the top level comments.

--- a/core/modules/comment/tests/modules/comment_test_views/test_views/views.view.test_comment_rest.yml
+++ b/core/modules/comment/tests/modules/comment_test_views/test_views/views.view.test_comment_rest.yml
@@ -338,7 +338,7 @@ display:
       arguments:
         nid:
           id: nid
-          table: node
+          table: node_field_data
           field: nid
           relationship: node
           group_type: group

--- a/core/modules/config/src/StorageReplaceDataWrapper.php
+++ b/core/modules/config/src/StorageReplaceDataWrapper.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\config\StorageReplaceDataWrapper.
+ */
+
+namespace Drupal\config;
+
+use Drupal\Core\Config\StorageInterface;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+/**
+ * Wraps a configuration storage to allow replacing specific configuration data.
+ */
+class StorageReplaceDataWrapper implements StorageInterface {
+  use DependencySerializationTrait;
+
+  /**
+   * The configuration storage to be wrapped.
+   *
+   * @var \Drupal\Core\Config\StorageInterface
+   */
+  protected $storage;
+
+  /**
+   * The configuration replacement data, keyed by configuration object name.
+   *
+   * @var array
+   */
+  protected $replacementData = [];
+
+  /**
+   * The storage collection.
+   *
+   * @var string
+   */
+  protected $collection;
+
+  /**
+   * Constructs a new StorageReplaceDataWrapper.
+   *
+   * @param \Drupal\Core\Config\StorageInterface $storage
+   *   A configuration storage to be used to read and write configuration.
+   * @param string $collection
+   *   (optional) The collection to store configuration in. Defaults to the
+   *   default collection.
+   */
+  public function __construct(StorageInterface $storage, $collection = StorageInterface::DEFAULT_COLLECTION) {
+    $this->storage = $storage;
+    $this->collection = $collection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function exists($name) {
+    return isset($this->replacementData[$this->collection][$name]) || $this->storage->exists($name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function read($name) {
+    if (isset($this->replacementData[$this->collection][$name])) {
+      return $this->replacementData[$this->collection][$name];
+    }
+    return $this->storage->read($name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function readMultiple(array $names) {
+    $data = $this->storage->readMultiple(($names));
+    foreach ($names as $name) {
+      if (isset($this->replacementData[$this->collection][$name])) {
+        $data[$name] = $this->replacementData[$this->collection][$name];
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function write($name, array $data) {
+    if (isset($this->replacementData[$this->collection][$name])) {
+      unset($this->replacementData[$this->collection][$name]);
+    }
+    return $this->storage->write($name, $data);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function delete($name) {
+    if (isset($this->replacementData[$this->collection][$name])) {
+      unset($this->replacementData[$this->collection][$name]);
+    }
+    return $this->storage->delete($name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function rename($name, $new_name) {
+    if (isset($this->replacementData[$this->collection][$name])) {
+      $this->replacementData[$this->collection][$new_name] = $this->replacementData[$this->collection][$name];
+      unset($this->replacementData[$this->collection][$name]);
+    }
+    return $this->rename($name, $new_name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function encode($data) {
+    return $this->storage->encode($data);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function decode($raw) {
+    return $this->storage->decode($raw);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function listAll($prefix = '') {
+    $names = $this->storage->listAll($prefix);
+    $additional_names = [];
+    if ($prefix === '') {
+      $additional_names = array_keys($this->replacementData[$this->collection]);
+    }
+    else {
+      foreach (array_keys($this->replacementData[$this->collection]) as $name) {
+        if (strpos($name, $prefix) === 0) {
+          $additional_names[] = $name;
+        }
+      }
+    }
+    if (!empty($additional_names)) {
+      $names = array_unique(array_merge($names, $additional_names));
+    }
+    return $names;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteAll($prefix = '') {
+    if ($prefix === '') {
+      $this->replacementData[$this->collection] = [];
+    }
+    else {
+      foreach (array_keys($this->replacementData[$this->collection]) as $name) {
+        if (strpos($name, $prefix) === 0) {
+          unset($this->replacementData[$this->collection][$name]);
+        }
+      }
+    }
+    return $this->storage->deleteAll($prefix);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createCollection($collection) {
+    $this->collection = $collection;
+    return $this->storage->createCollection($collection);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getAllCollectionNames() {
+    return $this->storage->getAllCollectionNames();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCollectionName() {
+    return $this->collection;
+  }
+
+  /**
+   * Replaces the configuration object data with the supplied data.
+   *
+   * @param $name
+   *   The configuration object name whose data to replace.
+   * @param array $data
+   *   The configuration data.
+   *
+   * @return $this
+   */
+  public function replaceData($name, array $data) {
+    $this->replacementData[$this->collection][$name] = $data;
+    return $this;
+  }
+}

--- a/core/modules/config/src/Tests/ConfigSingleImportExportTest.php
+++ b/core/modules/config/src/Tests/ConfigSingleImportExportTest.php
@@ -66,7 +66,7 @@ EOD;
     $this->assertIdentical($entity->label(), 'First');
     $this->assertIdentical($entity->id(), 'first');
     $this->assertTrue($entity->status());
-    $this->assertRaw(t('The @entity_type %label was imported.', array('@entity_type' => 'config_test', '%label' => $entity->label())));
+    $this->assertRaw(t('The configuration was imported successfully.'));
 
     // Attempt an import with an existing ID but missing UUID.
     $this->drupalPostForm('admin/config/development/configuration/single/import', $edit, t('Import'));
@@ -82,8 +82,7 @@ EOD;
     $this->drupalPostForm('admin/config/development/configuration/single/import', $edit, t('Import'));
     $this->assertRaw(t('Are you sure you want to create a new %name @type?', array('%name' => 'custom_id', '@type' => 'test configuration')));
     $this->drupalPostForm(NULL, array(), t('Confirm'));
-    $entity = $storage->load('custom_id');
-    $this->assertRaw(t('The @entity_type %label was imported.', array('@entity_type' => 'config_test', '%label' => $entity->label())));
+    $this->assertRaw(t('The configuration was imported successfully.'));
 
     // Perform an import with a unique ID and UUID.
     $import = <<<EOD
@@ -103,7 +102,7 @@ EOD;
     $this->assertRaw(t('Are you sure you want to create a new %name @type?', array('%name' => 'second', '@type' => 'test configuration')));
     $this->drupalPostForm(NULL, array(), t('Confirm'));
     $entity = $storage->load('second');
-    $this->assertRaw(t('The @entity_type %label was imported.', array('@entity_type' => 'config_test', '%label' => $entity->label())));
+    $this->assertRaw(t('The configuration was imported successfully.'));
     $this->assertIdentical($entity->label(), 'Second');
     $this->assertIdentical($entity->id(), 'second');
     $this->assertFalse($entity->status());
@@ -126,8 +125,27 @@ EOD;
     $this->assertRaw(t('Are you sure you want to update the %name @type?', array('%name' => 'second', '@type' => 'test configuration')));
     $this->drupalPostForm(NULL, array(), t('Confirm'));
     $entity = $storage->load('second');
-    $this->assertRaw(t('The @entity_type %label was imported.', array('@entity_type' => 'config_test', '%label' => $entity->label())));
+    $this->assertRaw(t('The configuration was imported successfully.'));
     $this->assertIdentical($entity->label(), 'Second updated');
+
+    // Try to perform an update which adds missing dependencies.
+    $import = <<<EOD
+id: second
+uuid: $second_uuid
+label: 'Second updated'
+weight: 0
+style: ''
+status: '0'
+dependencies:
+  module:
+    - does_not_exist
+EOD;
+    $edit = array(
+      'config_type' => 'config_test',
+      'import' => $import,
+    );
+    $this->drupalPostForm('admin/config/development/configuration/single/import', $edit, t('Import'));
+    $this->assertRaw(t('Configuration %name depends on the %owner module that will not be installed after import.', ['%name' => 'config_test.dynamic.second', '%owner' => 'does_not_exist']));
   }
 
   /**
@@ -150,6 +168,20 @@ EOD;
     $this->drupalPostForm(NULL, array(), t('Confirm'));
     $this->drupalGet('');
     $this->assertText('Test simple import');
+
+    // Ensure that ConfigImporter validation is running when importing simple
+    // configuration.
+    $config_data = $this->config('core.extension')->get();
+    // Simulate uninstalling the Config module.
+    unset($config_data['module']['config']);
+    $edit = array(
+      'config_type' => 'system.simple',
+      'config_name' => 'core.extension',
+      'import' => Yaml::encode($config_data),
+    );
+    $this->drupalPostForm('admin/config/development/configuration/single/import', $edit, t('Import'));
+    $this->assertText(t('Can not uninstall the Configuration module as part of a configuration synchronization through the user interface.'));
+
   }
 
   /**

--- a/core/modules/datetime/tests/modules/datetime_test/test_views/views.view.test_argument_datetime.yml
+++ b/core/modules/datetime/tests/modules/datetime_test/test_views/views.view.test_argument_datetime.yml
@@ -27,7 +27,7 @@ display:
           field: nid
           id: nid
           relationship: none
-          table: node
+          table: node_field_data
           plugin_id: numeric
       pager:
         options:
@@ -39,7 +39,7 @@ display:
           id: nid
           order: ASC
           relationship: none
-          table: node
+          table: node_field_data
           plugin_id: numeric
     display_plugin: default
     display_title: Master

--- a/core/modules/datetime/tests/modules/datetime_test/test_views/views.view.test_filter_datetime.yml
+++ b/core/modules/datetime/tests/modules/datetime_test/test_views/views.view.test_filter_datetime.yml
@@ -24,7 +24,7 @@ display:
         nid:
           field: nid
           id: nid
-          table: node
+          table: node_field_data
           plugin_id: node
       filters:
         field_date_value:
@@ -38,7 +38,7 @@ display:
           id: nid
           order: ASC
           relationship: none
-          table: node
+          table: node_field_data
           plugin_id: numeric
       pager:
         type: full

--- a/core/modules/datetime/tests/modules/datetime_test/test_views/views.view.test_sort_datetime.yml
+++ b/core/modules/datetime/tests/modules/datetime_test/test_views/views.view.test_sort_datetime.yml
@@ -24,7 +24,7 @@ display:
         nid:
           field: nid
           id: nid
-          table: node
+          table: node_field_data
           plugin_id: node
       sorts:
         field_date_value:
@@ -39,7 +39,7 @@ display:
           id: nid
           order: ASC
           relationship: none
-          table: node
+          table: node_field_data
           plugin_id: numeric
       pager:
         type: full

--- a/core/modules/field/tests/modules/field_test_views/test_views/views.view.test_view_fieldapi.yml
+++ b/core/modules/field/tests/modules/field_test_views/test_views/views.view.test_view_fieldapi.yml
@@ -9,7 +9,7 @@ label: test_view_fieldapi
 module: views
 description: ''
 tag: default
-base_table: node
+base_table: node_field_data
 base_field: nid
 core: '8'
 display:
@@ -21,7 +21,7 @@ display:
         nid:
           field: nid
           id: nid
-          table: node
+          table: node_field_data
           plugin_id: field
           entity_type: node
           entity_field: nid

--- a/core/modules/file/src/FileStorageInterface.php
+++ b/core/modules/file/src/FileStorageInterface.php
@@ -7,12 +7,12 @@
 
 namespace Drupal\file;
 
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 
 /**
  * Defines an interface for file entity storage classes.
  */
-interface FileStorageInterface extends EntityStorageInterface {
+interface FileStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Determines total disk space used by a single user or the whole filesystem.

--- a/core/modules/node/src/NodeStorageInterface.php
+++ b/core/modules/node/src/NodeStorageInterface.php
@@ -7,14 +7,14 @@
 
 namespace Drupal\node;
 
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Session\AccountInterface;
 
 /**
  * Defines an interface for node entity storage classes.
  */
-interface NodeStorageInterface extends EntityStorageInterface {
+interface NodeStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Gets a list of node revision IDs for a specific node.

--- a/core/modules/node/src/NodeViewsData.php
+++ b/core/modules/node/src/NodeViewsData.php
@@ -240,7 +240,7 @@ class NodeViewsData extends EntityViewsData {
         'title' => t('Content'),
         'label' => t('Get the actual content from a content revision.'),
       ),
-    ) + $data['node_revision']['vid'];
+    ) + $data['node_field_revision']['vid'];
 
     $data['node_field_revision']['langcode']['help'] = t('The language the original content is in.');
 

--- a/core/modules/rest/tests/modules/rest_test_views/test_views/views.view.test_serializer_node_display_field.yml
+++ b/core/modules/rest/tests/modules/rest_test_views/test_views/views.view.test_serializer_node_display_field.yml
@@ -41,7 +41,7 @@ display:
       fields:
         nid:
           id: nid
-          table: node
+          table: node_field_data
           field: nid
           plugin_id: field
           entity_type: node

--- a/core/modules/rest/tests/modules/rest_test_views/test_views/views.view.test_serializer_node_exposed_filter.yml
+++ b/core/modules/rest/tests/modules/rest_test_views/test_views/views.view.test_serializer_node_exposed_filter.yml
@@ -41,7 +41,7 @@ display:
       fields:
         nid:
           id: nid
-          table: node
+          table: node_field_data
           field: nid
           plugin_id: field
           entity_type: node

--- a/core/modules/system/src/Tests/Entity/EntityTranslationTest.php
+++ b/core/modules/system/src/Tests/Entity/EntityTranslationTest.php
@@ -328,6 +328,7 @@ class EntityTranslationTest extends EntityLanguageTestBase {
     // Verify that we obtain the entity object itself when we attempt to
     // retrieve a translation referring to it.
     $translation = $entity->getTranslation(LanguageInterface::LANGCODE_NOT_SPECIFIED);
+    $this->assertFalse($translation->isNewTranslation(), 'Existing translations are not marked as new.');
     $this->assertIdentical($entity, $translation, 'The translation object corresponding to a non-default language is the entity object itself when the entity is language-neutral.');
     $entity->{$langcode_key}->value = $default_langcode;
     $translation = $entity->getTranslation($default_langcode);
@@ -353,6 +354,7 @@ class EntityTranslationTest extends EntityLanguageTestBase {
     $entity->name->value = $name;
     $name_translated = $langcode . '_' . $this->randomMachineName();
     $translation = $entity->addTranslation($langcode);
+    $this->assertTrue($translation->isNewTranslation(), 'Newly added translations are marked as new.');
     $this->assertNotIdentical($entity, $translation, 'The entity and the translation object differ from one another.');
     $this->assertTrue($entity->hasTranslation($langcode), 'The new translation exists.');
     $this->assertEqual($translation->language()->getId(), $langcode, 'The translation language matches the specified one.');

--- a/core/modules/system/tests/modules/keyvalue_test/keyvalue_test.module
+++ b/core/modules/system/tests/modules/keyvalue_test/keyvalue_test.module
@@ -11,7 +11,7 @@
 function keyvalue_test_entity_type_alter(array &$entity_types) {
   /** @var $entity_types \Drupal\Core\Entity\EntityTypeInterface[] */
   if (isset($entity_types['entity_test_label'])) {
-    $entity_types['entity_test_label']->setStorageClass('Drupal\Core\Entity\KeyValueStore\KeyValueEntityStorage');
+    $entity_types['entity_test_label']->setStorageClass('Drupal\Core\Entity\KeyValueStore\KeyValueContentEntityStorage');
     $entity_keys = $entity_types['entity_test_label']->getKeys();
     $entity_types['entity_test_label']->set('entity_keys', $entity_keys + array('uuid' => 'uuid'));
   }

--- a/core/modules/taxonomy/src/TermStorageInterface.php
+++ b/core/modules/taxonomy/src/TermStorageInterface.php
@@ -8,12 +8,12 @@
 namespace Drupal\taxonomy;
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 
 /**
  * Defines an interface for taxonomy_term entity storage classes.
  */
-interface TermStorageInterface extends EntityStorageInterface {
+interface TermStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Removed reference to terms from term_hierarchy.

--- a/core/modules/taxonomy/tests/modules/taxonomy_test_views/test_views/views.view.test_groupwise_term.yml
+++ b/core/modules/taxonomy/tests/modules/taxonomy_test_views/test_views/views.view.test_groupwise_term.yml
@@ -59,7 +59,7 @@ display:
           subquery_namespace: ''
           subquery_order: DESC
           subquery_regenerate: true
-          subquery_sort: node.nid
+          subquery_sort: node_field_data.nid
           subquery_view: ''
           table: taxonomy_term_field_data
           plugin_id: groupwise_max

--- a/core/modules/taxonomy/tests/modules/taxonomy_test_views/test_views/views.view.test_taxonomy_term_relationship.yml
+++ b/core/modules/taxonomy/tests/modules/taxonomy_test_views/test_views/views.view.test_taxonomy_term_relationship.yml
@@ -156,7 +156,7 @@ display:
           plugin_id: field
         nid:
           id: nid
-          table: node
+          table: node_field_data
           field: nid
           entity_type: node
           entity_field: nid

--- a/core/modules/user/src/UserStorageInterface.php
+++ b/core/modules/user/src/UserStorageInterface.php
@@ -7,13 +7,13 @@
 
 namespace Drupal\user;
 
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\ContentEntityStorageInterface;
 use Drupal\Core\Session\AccountInterface;
 
 /**
  * Defines an interface for user entity storage classes.
  */
-interface UserStorageInterface extends EntityStorageInterface{
+interface UserStorageInterface extends ContentEntityStorageInterface {
 
   /**
    * Update the last login timestamp of the user.

--- a/core/modules/views/src/EntityViewsData.php
+++ b/core/modules/views/src/EntityViewsData.php
@@ -116,11 +116,29 @@ class EntityViewsData implements EntityHandlerInterface, EntityViewsDataInterfac
   public function getViewsData() {
     $data = [];
 
-    $base_table = $this->entityType->getBaseTable();
+    $base_table = $this->entityType->getBaseTable() ?: $this->entityType->id();
+    $revisionable = $this->entityType->isRevisionable();
     $base_field = $this->entityType->getKey('id');
-    $data_table = $this->entityType->getDataTable();
-    $revision_table = $this->entityType->getRevisionTable();
-    $revision_data_table = $this->entityType->getRevisionDataTable();
+
+    $revision_table = '';
+    if ($revisionable) {
+      $revision_table = $this->entityType->getRevisionTable() ?: $this->entityType->id() . '_revision';
+    }
+
+    $translatable = $this->entityType->isTranslatable();
+    $data_table = '';
+    if ($translatable) {
+      $data_table = $this->entityType->getDataTable() ?: $this->entityType->id() . '_field_data';
+    }
+
+    // Some entity types do not have a revision data table defined, but still
+    // have a revision table name set in
+    // \Drupal\Core\Entity\Sql\SqlContentEntityStorage::initTableLayout() so we
+    // apply the same kind of logic.
+    $revision_data_table = '';
+    if ($revisionable && $translatable) {
+      $revision_data_table = $this->entityType->getRevisionDataTable() ?: $this->entityType->id() . '_field_revision';
+    }
     $revision_field = $this->entityType->getKey('revision');
 
     // Setup base information of the views data.
@@ -213,6 +231,10 @@ class EntityViewsData implements EntityHandlerInterface, EntityViewsDataInterfac
     // the entity base, revision, data tables.
     $field_definitions = $this->entityManager->getBaseFieldDefinitions($this->entityType->id());
     if ($table_mapping = $this->storage->getTableMapping()) {
+      // Fetch all fields that can appear in both the base table and the data
+      // table.
+      $entity_keys = $this->entityType->getKeys();
+      $duplicate_fields = array_intersect_key($entity_keys, array_flip(['id', 'revision', 'bundle']));
       // Iterate over each table we have so far and collect field data for each.
       // Based on whether the field is in the field_definitions provided by the
       // entity manager.
@@ -221,6 +243,12 @@ class EntityViewsData implements EntityHandlerInterface, EntityViewsDataInterfac
       // @todo https://www.drupal.org/node/2337511
       foreach ($table_mapping->getTableNames() as $table) {
         foreach ($table_mapping->getFieldNames($table) as $field_name) {
+          // To avoid confusing duplication in the user interface, for fields
+          // that are on both base and data tables, only add them on the data
+          // table (same for revision vs. revision data).
+          if ($data_table && ($table === $base_table || $table === $revision_table) && in_array($field_name, $duplicate_fields)) {
+            continue;
+          }
           $this->mapFieldDefinition($table, $field_name, $field_definitions[$field_name], $table_mapping, $data[$table]);
         }
       }

--- a/core/modules/views/src/Tests/Update/FieldHandlersUpdateTest.php
+++ b/core/modules/views/src/Tests/Update/FieldHandlersUpdateTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Contains \Drupal\views\Tests\Update\FieldHandlersUpdateTest.
+ */
+
+namespace Drupal\views\Tests\Update;
+
+use Drupal\system\Tests\Update\UpdatePathTestBase;
+use Drupal\views\Entity\View;
+
+/**
+ * Tests the upgrade path for views field handlers.
+ *
+ * @see views_post_update_cleanup_duplicate_views_data()
+ *
+ * @group Update
+ */
+class FieldHandlersUpdateTest extends UpdatePathTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setDatabaseDumpFiles() {
+    $this->databaseDumpFiles = [
+      __DIR__ . '/../../../../system/tests/fixtures/update/drupal-8.bare.standard.php.gz',
+      __DIR__ . '/../../../tests/fixtures/update/duplicate-field-handler.php',
+    ];
+  }
+
+  /**
+   * Tests that field handlers are updated properly.
+   */
+  public function testViewsUpdate8004() {
+    $this->runUpdates();
+
+    // Load and initialize our test view.
+    $view = View::load('test_duplicate_field_handlers');
+    $data = $view->toArray();
+    // Check that the field is using the expected base table.
+    $this->assertEqual('node_field_data', $data['display']['default']['display_options']['fields']['nid']['table']);
+    $this->assertEqual('node_field_data', $data['display']['default']['display_options']['filters']['type']['table']);
+    $this->assertEqual('node_field_data', $data['display']['default']['display_options']['sorts']['vid']['table']);
+    $this->assertEqual('node_field_data', $data['display']['default']['display_options']['arguments']['nid']['table']);
+  }
+
+}

--- a/core/modules/views/tests/fixtures/update/duplicate-field-handler.php
+++ b/core/modules/views/tests/fixtures/update/duplicate-field-handler.php
@@ -1,0 +1,11 @@
+<?php
+
+$connection = Drupal\Core\Database\Database::getConnection();
+
+$connection->insert('config')
+  ->fields(array(
+    'collection' => '',
+    'name' => 'views.view.test_duplicate_field_handlers',
+    'data' => serialize(\Drupal\Component\Serialization\Yaml::decode(file_get_contents('core/modules/views/tests/modules/views_test_config/test_views/views.view.test_duplicate_field_handlers.yml'))),
+  ))
+  ->execute();

--- a/core/modules/views/tests/modules/views_test_config/test_views/views.view.test_duplicate_field_handlers.yml
+++ b/core/modules/views/tests/modules/views_test_config/test_views/views.view.test_duplicate_field_handlers.yml
@@ -1,11 +1,13 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - node.type.article
   module:
     - node
     - user
-id: test_nid_argument
-label: test_nid_argument
+id: test_duplicate_field_handlers
+label: 'Test Duplicate Field Handlers'
 module: views
 description: ''
 tag: ''
@@ -56,7 +58,7 @@ display:
       fields:
         nid:
           id: nid
-          table: node_field_data
+          table: node
           field: nid
           relationship: none
           group_type: group
@@ -120,9 +122,63 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: field
-      filters: {  }
-      sorts: {  }
-      title: test_nid_argument
+      filters:
+        type:
+          id: type
+          table: node
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            article: article
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        vid:
+          id: vid
+          table: node
+          field: vid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: vid
+          plugin_id: standard
+      title: 'Test Duplicate Field Handlers'
       header: {  }
       footer: {  }
       empty: {  }
@@ -130,7 +186,7 @@ display:
       arguments:
         nid:
           id: nid
-          table: node_field_data
+          table: node
           field: nid
           relationship: none
           group_type: group
@@ -140,8 +196,8 @@ display:
             value: all
             title_enable: false
             title: All
-          title_enable: true
-          title: '{{ arguments.nid }}'
+          title_enable: false
+          title: ''
           default_argument_type: fixed
           default_argument_options:
             argument: ''
@@ -164,13 +220,12 @@ display:
           not: false
           entity_type: node
           entity_field: nid
-          plugin_id: node_nid
+          plugin_id: numeric
       display_extenders: {  }
     cache_metadata:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - 'user.node_grants:view'
         - user.permissions
       cacheable: false
@@ -181,12 +236,11 @@ display:
     position: 1
     display_options:
       display_extenders: {  }
-      path: test-nid-argument
+      path: test-duplicate-field-handlers
     cache_metadata:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
-        - url
         - 'user.node_grants:view'
         - user.permissions
       cacheable: false

--- a/core/modules/views/tests/modules/views_test_config/test_views/views.view.test_row_render_cache.yml
+++ b/core/modules/views/tests/modules/views_test_config/test_views/views.view.test_row_render_cache.yml
@@ -130,7 +130,7 @@ display:
       fields:
         nid:
           id: nid
-          table: node
+          table: node_field_data
           field: nid
           relationship: none
           group_type: group

--- a/core/modules/views/views.post_update.php
+++ b/core/modules/views/views.post_update.php
@@ -5,6 +5,9 @@
  * Post update functions for Views.
  */
 
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\views\Views;
+
 /**
  * @addtogroup updates-8.0.0-beta
  * @{
@@ -29,6 +32,99 @@ function views_post_update_update_cacheability_metadata() {
     $view->save();
   }
 
+}
+
+/**
+ * Update some views fields that were previously duplicated.
+ */
+function views_post_update_cleanup_duplicate_views_data() {
+  $config_factory = \Drupal::configFactory();
+  $ids = [];
+  $message = NULL;
+  $data_tables = [];
+  $base_tables = [];
+  $revision_tables = [];
+  $entities_by_table = [];
+  $duplicate_fields = [];
+  $handler_types = Views::getHandlerTypes();
+
+  /** @var \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager */
+  $entity_type_manager = \Drupal::service('entity_type.manager');
+  // This will allow us to create an index of all entity types of the site.
+  foreach ($entity_type_manager->getDefinitions() as $entity_type_id => $entity_type) {
+    // Store the entity keyed by base table. If it has a data table, use that as
+    // well.
+    if ($data_table = $entity_type->getDataTable()) {
+      $entities_by_table[$data_table] = $entity_type;
+    }
+    if ($base_table = $entity_type->getBaseTable()) {
+      $entities_by_table[$base_table] = $entity_type;
+    }
+
+    // The following code basically contains the same kind of logic as
+    // \Drupal\Core\Entity\Sql\SqlContentEntityStorage::initTableLayout() to
+    // prefetch all tables (base, data, revision, and revision data).
+    $base_tables[$entity_type_id] = $entity_type->getBaseTable() ?: $entity_type->id();
+    $revisionable = $entity_type->isRevisionable();
+
+    $revision_table = '';
+    if ($revisionable) {
+      $revision_table = $entity_type->getRevisionTable() ?: $entity_type->id() . '_revision';
+    }
+    $revision_tables[$entity_type_id] = $revision_table;
+
+    $translatable = $entity_type->isTranslatable();
+    $data_table = '';
+    // For example the data table just exists, when the entity type is
+    // translatable.
+    if ($translatable) {
+      $data_table = $entity_type->getDataTable() ?: $entity_type->id() . '_field_data';
+    }
+    $data_tables[$entity_type_id] = $data_table;
+
+    $duplicate_fields[$entity_type_id] = array_intersect_key($entity_type->getKeys(), array_flip(['id', 'revision', 'bundle']));
+  }
+
+  foreach ($config_factory->listAll('views.view.') as $view_config_name) {
+    $changed = FALSE;
+    $view = $config_factory->getEditable($view_config_name);
+
+    $displays = $view->get('display');
+    if (isset($entities_by_table[$view->get('base_table')])) {
+      $entity_type = $entities_by_table[$view->get('base_table')];
+      $entity_type_id = $entity_type->id();
+      $data_table = $data_tables[$entity_type_id];
+      $base_table = $base_tables[$entity_type_id];
+      $revision_table = $revision_tables[$entity_type_id];
+
+      if ($data_table) {
+        foreach ($displays as $display_name => &$display) {
+          foreach ($handler_types as $handler_type) {
+            if (!empty($display['display_options'][$handler_type['plural']])) {
+              foreach ($display['display_options'][$handler_type['plural']] as $field_name => &$field) {
+                $table = $field['table'];
+                if (($table === $base_table || $table === $revision_table) && in_array($field_name, $duplicate_fields[$entity_type_id])) {
+                  $field['table'] = $data_table;
+                  $changed = TRUE;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if ($changed) {
+      $view->set('display', $displays);
+      $view->save();
+      $ids[] = $view->get('id');
+    }
+  }
+  if (!empty($ids)) {
+    $message = new TranslatableMarkup('Updated tables for field handlers for views: @ids', ['@ids' => implode(', ', array_unique($ids))]);
+  }
+
+  return $message;
 }
 
 /**

--- a/core/modules/views_ui/src/Tests/HandlerTest.php
+++ b/core/modules/views_ui/src/Tests/HandlerTest.php
@@ -10,6 +10,7 @@ namespace Drupal\views_ui\Tests;
 use Drupal\Component\Utility\SafeMarkup;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\views\Tests\ViewTestData;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -21,11 +22,16 @@ use Drupal\views\ViewExecutable;
 class HandlerTest extends UITestBase {
 
   /**
+   * {@inheritdoc}
+   */
+  public static $modules = array('node_test_views');
+
+  /**
    * Views used by this test.
    *
    * @var array
    */
-  public static $testViews = array('test_view_empty', 'test_view_broken', 'node');
+  public static $testViews = array('test_view_empty', 'test_view_broken', 'node', 'test_node_view');
 
   /**
    * {@inheritdoc}
@@ -34,6 +40,7 @@ class HandlerTest extends UITestBase {
     parent::setUp();
 
     $this->drupalPlaceBlock('page_title_block');
+    ViewTestData::createTestViews(get_class($this), array('node_test_views'));
   }
 
   /**
@@ -218,4 +225,37 @@ class HandlerTest extends UITestBase {
     }
   }
 
+  /**
+   * Ensures that neither node type or node ID appears multiple times.
+   *
+   * @see \Drupal\views\EntityViewsData
+   */
+  public function testNoDuplicateFields() {
+    $handler_types = ['field', 'filter', 'sort', 'argument'];
+
+    foreach ($handler_types as $handler_type) {
+      $add_handler_url = 'admin/structure/views/nojs/add-handler/test_node_view/default/' . $handler_type;
+      $this->drupalGet($add_handler_url);
+
+      $this->assertNoDuplicateField('Node ID', 'Content');
+      $this->assertNoDuplicateField('Node ID', 'Content revision');
+      $this->assertNoDuplicateField('Type', 'Content');
+      $this->assertNoDuplicateField('UUID', 'Content');
+      $this->assertNoDuplicateField('Revision ID', 'Content');
+      $this->assertNoDuplicateField('Revision ID', 'Content revision');
+    }
+  }
+
+  /**
+   * Asserts that fields only appear once.
+   *
+   * @param string $field_name
+   *   The field name.
+   * @param string $entity_type
+   *   The entity type to which the field belongs.
+   */
+  public function assertNoDuplicateField($field_name, $entity_type) {
+    $elements = $this->xpath('//td[.=:entity_type]/preceding-sibling::td[@class="title" and .=:title]', [':title' => $field_name, ':entity_type' => $entity_type]);
+    $this->assertEqual(1, count($elements), $field_name . ' appears just once in ' . $entity_type .  '.');
+  }
 }

--- a/sites/default/default.settings.php
+++ b/sites/default/default.settings.php
@@ -700,6 +700,17 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
  */
 
 /**
+ * Include the Pantheon-specific settings file.
+ *
+ * n.b. The settings.pantheon.php file makes some changes
+ *      that affect all envrionments that this site
+ *      exists in.  Always include this file, even in
+ *      a local development environment, to insure that
+ *      the site settings remain consistent.
+ */
+include __DIR__ . "/settings.pantheon.php";
+
+/**
  * Load local development override configuration, if available.
  *
  * Use settings.local.php to override variables on secondary (staging,
@@ -709,6 +720,6 @@ $settings['container_yamls'][] = __DIR__ . '/services.yml';
  *
  * Keep this code block at the end of this file to take full effect.
  */
-# if (file_exists(__DIR__ . '/settings.local.php')) {
-#   include __DIR__ . '/settings.local.php';
-# }
+if (file_exists(__DIR__ . '/settings.local.php')) {
+  include __DIR__ . '/settings.local.php';
+}

--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -47,20 +47,6 @@ else {
   );
 }
 
-/**
- * Override the $install_state variable to let Drupal know that the settings are verified
- * since they are being passed directly by the Pantheon.
- *
- * Issue: https://github.com/pantheon-systems/drops-8/issues/9
- *
- */
-if (
-  isset($_ENV['PANTHEON_ENVIRONMENT']) &&
-  $is_installer_url &&
-  (php_sapi_name() != "cli")
-) {
-  $GLOBALS['install_state']['settings_verified'] = TRUE;
-}
 
 /**
  * Allow Drupal 8 to Cleanly Redirect to Install.php For New Sites.
@@ -73,7 +59,7 @@ if (
 if (
   isset($_ENV['PANTHEON_ENVIRONMENT']) &&
   !$is_installer_url &&
-  (!is_dir(__DIR__ . '/files/styles')) &&
+  (isset($_SERVER['PANTHEON_DATABASE_STATE']) && ($_SERVER['PANTHEON_DATABASE_STATE'] == 'empty')) &&
   (empty($GLOBALS['install_state'])) &&
   (php_sapi_name() != "cli")
 ) {


### PR DESCRIPTION
For more information, see https://www.drupal.org/node/2619030

Instructions to test:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.0.0
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site. Step through the installation process. Look for any problems.

Note that the redirection to core/installer.php is now done by a new, cleaner platform feature that is [being deployed to the platform right now](https://github.com/pantheon-cookbooks/endpoint/pull/132). If you try to test this PR before this feature has converged on your instance, you will get a WSOD with a database error. Do not be alarmed; proceed to the installer by manually adding `/core/installer.php` to the URL, and continue with the test.

- Test standard and minimal installation profiles
- Test an English and non-English install
- Insure the update.php will run through the browser (manually visit /update.php)
- Insure that you can install modules through the admin interface
- Insure that 'is-active' is added where appropriate (active link text is black instead of blue when you move the Main Navigation menu to a sidebar)
- Do other general ad-hoc tests to suit, to make sure everything is working well
