### PR TITLE
Allow private directory to be committed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 sites/*/files
 sites/*/private
 files/*
-private/*
 
 # Pantheon commits a settings.php for environment-specific settings.
 # Place local settings in settings.local.php


### PR DESCRIPTION
The `private` direction is the recommended location where private (not served by webserver) assets should be committed to the repository.  It therefore should not have been included in the .gitignore file.