### PR TITLE
Update to Drupal 8.1.10.

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.1.9';
+  const VERSION = '8.1.10';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/EventSubscriber/DefaultExceptionSubscriber.php
+++ b/core/lib/Drupal/Core/EventSubscriber/DefaultExceptionSubscriber.php
@@ -188,13 +188,16 @@ class DefaultExceptionSubscriber implements EventSubscriberInterface {
     if (!method_exists($this, $method)) {
       if ($exception instanceof HttpExceptionInterface) {
         $this->onFormatUnknown($event);
+        $response = $event->getResponse();
+        $response->headers->set('Content-Type', 'text/plain');
       }
       else {
         $this->onHtml($event);
       }
-      return;
     }
-    $this->$method($event);
+    else {
+      $this->$method($event);
+    }
   }
 
   /**

--- a/core/modules/comment/src/Tests/CommentNonNodeTest.php
+++ b/core/modules/comment/src/Tests/CommentNonNodeTest.php
@@ -384,6 +384,7 @@ class CommentNonNodeTest extends WebTestBase {
       'administer entity_test fields',
       'view test entity',
       'administer entity_test content',
+      'administer comments',
     ));
     $this->drupalLogin($limited_user);
     $this->drupalGet('entity_test/structure/entity_test/fields/entity_test.entity_test.comment');

--- a/core/modules/comment/tests/src/Functional/CommentStatusFieldAccessTest.php
+++ b/core/modules/comment/tests/src/Functional/CommentStatusFieldAccessTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\Tests\comment\Functional;
+
+
+use Drupal\comment\Tests\CommentTestTrait;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests comment status field access.
+ *
+ * @group comment
+ */
+class CommentStatusFieldAccessTest extends BrowserTestBase {
+
+  use CommentTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public $profile = 'testing';
+
+  /**
+   * Comment admin.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $commentAdmin;
+
+  /**
+   * Node author.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $nodeAuthor;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'node',
+    'comment',
+    'user',
+    'system',
+    'text',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => t('Article'),
+    ]);
+    $node_type->save();
+    $this->nodeAuthor = $this->drupalCreateUser([
+      'create article content',
+      'skip comment approval',
+      'post comments',
+      'edit own comments',
+      'access comments',
+      'administer nodes',
+    ]);
+    $this->commentAdmin = $this->drupalCreateUser([
+      'administer comments',
+      'create article content',
+      'edit own comments',
+      'skip comment approval',
+      'post comments',
+      'access comments',
+      'administer nodes',
+    ]);
+    $this->addDefaultCommentField('node', 'article');
+  }
+
+  /**
+   * Tests comment status field access.
+   */
+  public function testCommentStatusFieldAccessStatus() {
+    $this->drupalLogin($this->nodeAuthor);
+    $this->drupalGet('node/add/article');
+    $assert = $this->assertSession();
+    $assert->fieldNotExists('comment[0][status]');
+    $this->submitForm([
+      'title[0][value]' => 'Node 1',
+    ], t('Save and publish'));
+    $assert->fieldExists('subject[0][value]');
+    $this->drupalLogin($this->commentAdmin);
+    $this->drupalGet('node/add/article');
+    $assert->fieldExists('comment[0][status]');
+    $this->submitForm([
+      'title[0][value]' => 'Node 2',
+    ], t('Save and publish'));
+    $assert->fieldExists('subject[0][value]');
+  }
+
+}

--- a/core/modules/config/config.module
+++ b/core/modules/config/config.module
@@ -65,14 +65,17 @@ function config_file_download($uri) {
   $scheme = file_uri_scheme($uri);
   $target = file_uri_target($uri);
   if ($scheme == 'temporary' && $target == 'config.tar.gz') {
-    $request = \Drupal::request();
-    $date = DateTime::createFromFormat('U', $request->server->get('REQUEST_TIME'));
-    $date_string = $date->format('Y-m-d-H-i');
-    $hostname = str_replace('.', '-', $request->getHttpHost());
-    $filename = 'config' . '-' . $hostname . '-' . $date_string . '.tar.gz';
-    $disposition = 'attachment; filename="' . $filename . '"';
-    return array(
-      'Content-disposition' => $disposition,
-    );
+    if (\Drupal::currentUser()->hasPermission('export configuration')) {
+      $request = \Drupal::request();
+      $date = DateTime::createFromFormat('U', $request->server->get('REQUEST_TIME'));
+      $date_string = $date->format('Y-m-d-H-i');
+      $hostname = str_replace('.', '-', $request->getHttpHost());
+      $filename = 'config' . '-' . $hostname . '-' . $date_string . '.tar.gz';
+      $disposition = 'attachment; filename="' . $filename . '"';
+      return array(
+        'Content-disposition' => $disposition,
+      );
+    }
+    return -1;
   }
 }

--- a/core/modules/config/src/Tests/ConfigExportUITest.php
+++ b/core/modules/config/src/Tests/ConfigExportUITest.php
@@ -88,6 +88,12 @@ class ConfigExportUITest extends WebTestBase {
     // Check the single export form doesn't have "form-required" elements.
     $this->drupalGet('admin/config/development/configuration/single/export');
     $this->assertNoRaw('js-form-required form-required', 'No form required fields are found.');
+
+    // Ensure the temporary file is not available to users without the
+    // permission.
+    $this->drupalLogout();
+    $this->drupalGet('system/temporary', ['query' => ['file' => 'config.tar.gz']]);
+    $this->assertResponse(403);
   }
 
 }


### PR DESCRIPTION
For more information, see https://www.drupal.org/project/drupal/releases/8.1.10

Instructions to test:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.1.10
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site. Step through the installation process. Look for any problems.
