### PR TITLE
Fixes #111: Allow users to adjust services.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,11 @@ files/*
 # Pantheon commits a settings.php for environment-specific settings.
 # Place local settings in settings.local.php
 sites/*/settings.local.php
-sites/*/services*.yml
+
+# Note that services.local.yml is not loaded by default. If you would like
+# to use this file add the following to your settings.local.php file:
+#   $settings['container_yamls'][] = __DIR__ . '/services.local.yml';
+sites/*/services.local.yml
 
 # ** Only works in OSs that support newer versions of fnmatch (Bash 4+)
 /sites/default/**/files

--- a/sites/default/default.services.pantheon.preproduction.yml
+++ b/sites/default/default.services.pantheon.preproduction.yml
@@ -1,0 +1,15 @@
+#
+# Rename this file to 'services.pantheon.preproduction.yml' and
+# modify to suit.  It will then be loaded by settings.pantheon.php
+# on any dev or multidev environment (not on 'test' or 'live').
+#
+# If you would like to define any services or service parameters
+# that apply only to production environments ('test' and 'live'),
+# you may do so in a 'services.pantheon.production.yml' file.
+#
+# See 'default.services.yml' for information on useful settings to
+# put here.
+#
+parameters:
+  twig.config:
+    debug: true

--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -25,7 +25,25 @@
  * not to any Drupal files.
  */
 if (!defined("PANTHEON_VERSION")) {
-  define("PANTHEON_VERSION", "2");
+  define("PANTHEON_VERSION", "3");
+}
+
+/**
+ * Determine whether this is a preproduction or production environment, and
+ * then load the pantheon services.yml file.  This file should be named either
+ * 'pantheon-production-services.yml' (for 'live' or 'test' environments)
+ * 'pantheon-preproduction-services.yml' (for 'dev' or multidev environments).
+ */
+$pantheon_services_file = __DIR__ . '/services.pantheon.preproduction.yml';
+if (
+  isset($_ENV['PANTHEON_ENVIRONMENT']) &&
+  ( ($_ENV['PANTHEON_ENVIRONMENT'] == 'live') || ($_ENV['PANTHEON_ENVIRONMENT'] == 'test') )
+) {
+  $pantheon_services_file = __DIR__ . '/services.pantheon.production.yml';
+}
+
+if (file_exists($pantheon_services_file)) {
+  $settings['container_yamls'][] = $pantheon_services_file;
 }
 
 /**
@@ -134,5 +152,3 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   $config['system.file']['path']['temporary'] = $_SERVER['HOME'] .'/tmp';
 }
-
-


### PR DESCRIPTION
Load 'services.pantheon.preproduction.yml' in dev and multidev environments, e.g. to turn on twig debugging.