### PR TITLE
Update to Drupal 8.2.1. 

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.2.0';
+  const VERSION = '8.2.1';
 
   /**
    * Core API compatibility.

--- a/core/modules/block/block.post_update.php
+++ b/core/modules/block/block.post_update.php
@@ -77,3 +77,36 @@ function block_post_update_disable_blocks_with_missing_contexts() {
 /**
  * @} End of "addtogroup updates-8.0.0-beta".
  */
+
+/**
+ * @addtogroup updates-8.2.x
+ * @{
+ */
+
+/**
+ * Fix invalid 'negate' values in block visibility conditions.
+ */
+function block_post_update_fix_negate_in_conditions() {
+  $block_storage = \Drupal::entityTypeManager()->getStorage('block');
+  /** @var \Drupal\block\BlockInterface[] $blocks */
+  $blocks = $block_storage->loadMultiple();
+  foreach ($blocks as $block) {
+    $block_needs_saving = FALSE;
+    // Check each visibility condition for an invalid negate value, and fix it.
+    foreach ($block->getVisibilityConditions() as $condition_id => $condition) {
+      $configuration = $condition->getConfiguration();
+      if (array_key_exists('negate', $configuration) && !is_bool($configuration['negate'])) {
+        $configuration['negate'] = (bool) $configuration['negate'];
+        $condition->setConfiguration($configuration);
+        $block_needs_saving = TRUE;
+      }
+    }
+    if ($block_needs_saving) {
+      $block->save();
+    }
+  }
+}
+
+/**
+ * @} End of "addtogroup updates-8.2.x".
+ */

--- a/core/modules/block/src/BlockForm.php
+++ b/core/modules/block/src/BlockForm.php
@@ -323,7 +323,7 @@ class BlockForm extends EntityForm {
       // However, certain form elements may return it as 0/1. Cast here to
       // ensure the data is in the expected type.
       if (array_key_exists('negate', $values)) {
-        $values['negate'] = (bool) $values['negate'];
+        $form_state->setValue(['visibility', $condition_id, 'negate'], (bool) $values['negate']);
       }
 
       // Allow the condition to validate the form.

--- a/core/modules/block/src/Tests/Update/BlockConditionMissingSchemaUpdateTest.php
+++ b/core/modules/block/src/Tests/Update/BlockConditionMissingSchemaUpdateTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\block\Tests\Update;
+
+use Drupal\system\Tests\Update\UpdatePathTestBase;
+
+/**
+ * Tests the upgrade path for block with conditions missing context.
+ *
+ * @see https://www.drupal.org/node/2811519
+ *
+ * @group Update
+ */
+class BlockConditionMissingSchemaUpdateTest extends UpdatePathTestBase {
+
+  /**
+   * This test does not have a failed update but the configuration has missing
+   * schema so can not do the full post update testing offered by
+   * UpdatePathTestBase.
+   *
+   * @var bool
+   *
+   * @see \Drupal\system\Tests\Update\UpdatePathTestBase::runUpdates()
+   */
+  protected $checkFailedUpdates = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['block_test', 'language'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setDatabaseDumpFiles() {
+    $this->databaseDumpFiles = [
+      __DIR__ . '/../../../../system/tests/fixtures/update/drupal-8.bare.standard.php.gz',
+      __DIR__ . '/../../../tests/fixtures/update/drupal-8.block-test-enabled-missing-schema.php',
+    ];
+  }
+
+  /**
+   * Tests that block context mapping is updated properly.
+   */
+  public function testUpdateHookN() {
+    $this->runUpdates();
+    $this->drupalGet('<front>');
+    // If the block is fixed by block_post_update_fix_negate_in_conditions()
+    // then it will be visible.
+    $this->assertText('Test missing schema on conditions');
+  }
+
+}

--- a/core/modules/block/tests/fixtures/update/block.block.missing_schema.yml
+++ b/core/modules/block/tests/fixtures/update/block.block.missing_schema.yml
@@ -1,0 +1,28 @@
+uuid: 1a6c0f14-78dc-4ede-bade-b8ce83881453
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_test
+    - system
+  theme:
+    - bartik
+id: missing_schema
+theme: bartik
+region: sidebar_first
+weight: 0
+provider: null
+plugin: system_branding_block
+settings:
+  id: system_branding_block
+  label: 'Test missing schema on conditions'
+  provider: system
+  label_display: visible
+  use_site_logo: true
+  use_site_name: true
+  use_site_slogan: true
+visibility:
+  missing_schema:
+    id: missing_schema
+    negate: 0
+    context_mapping: {  }

--- a/core/modules/block/tests/fixtures/update/drupal-8.block-test-enabled-missing-schema.php
+++ b/core/modules/block/tests/fixtures/update/drupal-8.block-test-enabled-missing-schema.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @file
+ * Partial database to mimic the installation of the block_test module.
+ */
+
+use Drupal\Core\Database\Database;
+use Symfony\Component\Yaml\Yaml;
+
+$connection = Database::getConnection();
+
+// Set the schema version.
+$connection->insert('key_value')
+  ->fields([
+    'collection' => 'system.schema',
+    'name' => 'block_test',
+    'value' => 'i:8000;',
+  ])
+  ->execute();
+
+// Update core.extension.
+$extensions = $connection->select('config')
+  ->fields('config', ['data'])
+  ->condition('collection', '')
+  ->condition('name', 'core.extension')
+  ->execute()
+  ->fetchField();
+$extensions = unserialize($extensions);
+$extensions['module']['block_test'] = 8000;
+$connection->update('config')
+  ->fields([
+    'data' => serialize($extensions),
+  ])
+  ->condition('collection', '')
+  ->condition('name', 'core.extension')
+  ->execute();
+
+// Install the block configuration.
+$config = file_get_contents(__DIR__ . '/block.block.missing_schema.yml');
+$config = Yaml::parse($config);
+$connection->insert('config')
+  ->fields(['data', 'name', 'collection'])
+  ->values([
+    'name' => 'block.block.missing_schema',
+    'data' => serialize($config),
+    'collection' => '',
+  ])
+  ->execute();

--- a/core/modules/block/tests/modules/block_test/src/Plugin/Condition/MissingSchema.php
+++ b/core/modules/block/tests/modules/block_test/src/Plugin/Condition/MissingSchema.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\block_test\Plugin\Condition;
+
+use Drupal\Core\Condition\ConditionPluginBase;
+
+/**
+ * Provides a 'missing_schema' condition.
+ *
+ * @Condition(
+ *   id = "missing_schema",
+ *   label = @Translation("Missing schema"),
+ * )
+ */
+class MissingSchema extends ConditionPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function evaluate() {
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function summary() {
+    return 'Summary';
+  }
+
+}

--- a/core/modules/content_moderation/src/Plugin/Field/ModerationStateFieldItemList.php
+++ b/core/modules/content_moderation/src/Plugin/Field/ModerationStateFieldItemList.php
@@ -23,6 +23,10 @@ class ModerationStateFieldItemList extends EntityReferenceFieldItemList {
   protected function getModerationState() {
     $entity = $this->getEntity();
 
+    if (!\Drupal::service('content_moderation.moderation_information')->shouldModerateEntitiesOfBundle($entity->getEntityType(), $entity->bundle())) {
+      return NULL;
+    }
+
     if ($entity->id() && $entity->getRevisionId()) {
       $revisions = \Drupal::service('entity.query')->get('content_moderation_state')
         ->condition('content_entity_type_id', $entity->getEntityTypeId())

--- a/core/modules/content_moderation/src/Tests/ModerationStateNodeTest.php
+++ b/core/modules/content_moderation/src/Tests/ModerationStateNodeTest.php
@@ -47,6 +47,7 @@ class ModerationStateNodeTest extends ModerationStateTestBase {
     }
 
     $node = reset($nodes);
+    $this->assertEqual('draft', $node->moderation_state->target_id);
 
     $path = 'node/' . $node->id() . '/edit';
     // Set up published revision.
@@ -55,6 +56,7 @@ class ModerationStateNodeTest extends ModerationStateTestBase {
     /* @var \Drupal\node\NodeInterface $node */
     $node = \Drupal::entityTypeManager()->getStorage('node')->load($node->id());
     $this->assertTrue($node->isPublished());
+    $this->assertEqual('published', $node->moderation_state->target_id);
 
     // Verify that the state field is not shown.
     $this->assertNoText('Published');
@@ -62,6 +64,31 @@ class ModerationStateNodeTest extends ModerationStateTestBase {
     // Delete the node.
     $this->drupalPostForm('node/' . $node->id() . '/delete', array(), t('Delete'));
     $this->assertText(t('The Moderated content moderated content has been deleted.'));
+
+    $this->drupalGet('admin/structure/types/manage/moderated_content/moderation');
+    $this->assertFieldByName('enable_moderation_state');
+    $this->assertFieldChecked('edit-enable-moderation-state');
+    $this->drupalPostForm(NULL, ['enable_moderation_state' => FALSE], t('Save'));
+    $this->drupalGet('admin/structure/types/manage/moderated_content/moderation');
+    $this->assertFieldByName('enable_moderation_state');
+    $this->assertNoFieldChecked('edit-enable-moderation-state');
+    $this->drupalPostForm('node/add/moderated_content', [
+      'title[0][value]' => 'non-moderated content',
+    ], t('Save and publish'));
+
+    $nodes = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->loadByProperties([
+        'title' => 'non-moderated content',
+      ]);
+
+    if (!$nodes) {
+      $this->fail('Non-moderated test node was not saved correctly.');
+      return;
+    }
+
+    $node = reset($nodes);
+    $this->assertEqual(NULL, $node->moderation_state->target_id);
   }
 
   /**


### PR DESCRIPTION
For more information, see https://www.drupal.org/project/drupal/releases/8.2.1

Instructions to test:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.2.1
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site. Step through the installation process. Look for any problems.