### PR TITLE
Update composer.json to use specific paths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,13 @@
             "recurse": false,
             "replace": false,
             "merge-extra": false
+        },
+        "installer-paths": {
+            "core": ["type:drupal-core"],
+            "modules/contrib/{$name}": ["type:drupal-module"],
+            "profiles/contrib/{$name}": ["type:drupal-profile"],
+            "themes/contrib/{$name}": ["type:drupal-theme"],
+            "drush/contrib/{$name}": ["type:drupal-drush"]
         }
     },
     "autoload": {


### PR DESCRIPTION
I figured I would post this since it is probably going to break a lot of sites soon because the latest version of ctools are being automatically installed (this bug) and the latest ctools has some incompatible changes with older versions of core.

Any Drupal modules that:

1) Define dependencies in their custom composer.json 
2) Are listed in the merge-plugin section of composer.json
3) Should be installed in modules/contrib/

Will install TWICE on the same site resulting in two separate versions of the module being installed on production!  EHH this is bad.  Composer Manager will amplify this effect across many modules.

It looks like in Drupal 8.4.x the composer.json file contains the following:

```
        "installer-paths": {
            "core": ["type:drupal-core"],
            "modules/contrib/{$name}": ["type:drupal-module"],
            "profiles/contrib/{$name}": ["type:drupal-profile"],
            "themes/contrib/{$name}": ["type:drupal-theme"],
            "drush/contrib/{$name}": ["type:drupal-drush"]
        }
```

Not sure when this was changed or when it will officially be released but it works on 8.2.6 by only installing modules in a single location (the location defined in this code section).  This PR does make an assumption that developers desire to install contrib modules in those locations above but considering core is eventually going to have it, it might be worth bumping up the release date of this change.