### PR TITLE
Update drops-8 to 8.3.1

### DIFF
--- a/core/CHANGELOG.txt
+++ b/core/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Drupal 8.3.1, 2017-04-19
+------------------------
+- Fixed security issues. See SA-CORE-2017-002.
+
 Drupal 8.3.0, 2017-04-05
 ------------------------
 - Added modules:

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.3.0';
+  const VERSION = '8.3.1';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Entity/EntityAccessControlHandler.php
+++ b/core/lib/Drupal/Core/Entity/EntityAccessControlHandler.php
@@ -303,6 +303,19 @@ class EntityAccessControlHandler extends EntityHandlerBase implements EntityAcce
     // Get the default access restriction that lives within this field.
     $default = $items ? $items->defaultAccess($operation, $account) : AccessResult::allowed();
 
+    // Explicitly disallow changing the entity ID and entity UUID.
+    if ($operation === 'edit') {
+      if ($field_definition->getName() === $this->entityType->getKey('id')) {
+        return $return_as_object ? AccessResult::forbidden('The entity ID cannot be changed') : FALSE;
+      }
+      elseif ($field_definition->getName() === $this->entityType->getKey('uuid')) {
+        // UUIDs can be set when creating an entity.
+        if ($items && ($entity = $items->getEntity()) && !$entity->isNew()) {
+          return $return_as_object ? AccessResult::forbidden('The entity UUID cannot be changed')->addCacheableDependency($entity) : FALSE;
+        }
+      }
+    }
+
     // Get the default access restriction as specified by the access control
     // handler.
     $entity_default = $this->checkFieldAccess($operation, $field_definition, $account, $items);

--- a/vendor/squizlabs/php_codesniffer/CodeSniffer.conf
+++ b/vendor/squizlabs/php_codesniffer/CodeSniffer.conf
@@ -1,5 +1,5 @@
 <?php
  $phpCodeSnifferConfig = array (
-  'installed_paths' => '/Users/ganderson/local/upstreams/update-drops8-tmp.roY/drops-8/vendor/drupal/coder/coder_sniffer',
+  'installed_paths' => '/Users/ganderson/local/upstreams/update-drops8-tmp.8MO/drops-8/vendor/drupal/coder/coder_sniffer',
 )
 ?>


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.3.1
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.