### PR TITLE
Update drops-8 to 8.3.1

### DIFF
--- a/vendor/squizlabs/php_codesniffer/CodeSniffer.conf
+++ b/vendor/squizlabs/php_codesniffer/CodeSniffer.conf
@@ -1,5 +1,5 @@
 <?php
  $phpCodeSnifferConfig = array (
-  'installed_paths' => '/Users/ganderson/local/upstreams/update-drops8-tmp.8MO/drops-8/vendor/drupal/coder/coder_sniffer',
+  'installed_paths' => '/Users/ganderson/local/upstreams/update-drops8-tmp.YKe/drops-8/vendor/drupal/coder/coder_sniffer',
 )
 ?>


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.3.1
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.