### PR TITLE
Update drops-8 to 8.3.4

### DIFF
--- a/core/CHANGELOG.txt
+++ b/core/CHANGELOG.txt
@@ -1,3 +1,7 @@
+Drupal 8.3.4, 2017-06-21
+------------------------
+- Fixed security issues. See SA-CORE-2017-003.
+
 Drupal 8.3.1, 2017-04-19
 ------------------------
 - Fixed security issues. See SA-CORE-2017-002.

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.3.3';
+  const VERSION = '8.3.4';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Component/Serialization/YamlPecl.php
+++ b/core/lib/Drupal/Component/Serialization/YamlPecl.php
@@ -27,6 +27,12 @@ class YamlPecl implements SerializationInterface {
    * {@inheritdoc}
    */
   public static function decode($raw) {
+    static $init;
+    if (!isset($init)) {
+      // We never want to unserialize !php/object.
+      ini_set('yaml.decode_php', 0);
+      $init = TRUE;
+    }
     // yaml_parse() will error with an empty value.
     if (!trim($raw)) {
       return NULL;

--- a/core/lib/Drupal/Core/Test/ObjectSerialization.php
+++ b/core/lib/Drupal/Core/Test/ObjectSerialization.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\Core\Test;
+
+/**
+ * Object to test that security issues around serialization.
+ */
+class ObjectSerialization {
+
+  /**
+   * ObjectSerialization constructor.
+   */
+  public function __construct() {
+    throw new \Exception('This object should never be constructed');
+  }
+
+  /**
+   * ObjectSerialization deconstructor.
+   */
+  public function __destruct() {
+    throw new \Exception('This object should never be destructed');
+  }
+
+}

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -904,6 +904,14 @@ function file_save_upload($form_field_name, $validators = [], $destination = FAL
     // If we made it this far it's safe to record this file in the database.
     $file->save();
     $files[$i] = $file;
+    // Allow an anonymous user who creates a non-public file to see it. See
+    // \Drupal\file\FileAccessControlHandler::checkAccess().
+    if ($user->isAnonymous() && $destination_scheme !== 'public') {
+      $session = \Drupal::request()->getSession();
+      $allowed_temp_files = $session->get('anonymous_allowed_file_ids', []);
+      $allowed_temp_files[$file->id()] = $file->id();
+      $session->set('anonymous_allowed_file_ids', $allowed_temp_files);
+    }
   }
 
   // Add files to the cache.

--- a/core/modules/file/src/Tests/FilePrivateTest.php
+++ b/core/modules/file/src/Tests/FilePrivateTest.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\Plugin\Validation\Constraint\ReferenceAccessConstraint;
 use Drupal\Component\Utility\SafeMarkup;
 use Drupal\file\Entity\File;
 use Drupal\node\Entity\NodeType;
+use Drupal\user\RoleInterface;
 
 /**
  * Uploads a test to a private node and checks access.
@@ -110,6 +111,118 @@ class FilePrivateTest extends FileFieldTestBase {
     $this->drupalLogin($account);
     $this->drupalGet($file_url);
     $this->assertResponse(403, 'Confirmed that access is denied for another user to the temporary file.');
+
+    // As an anonymous user, create a temporary file with no references and
+    // confirm that only the session that uploaded it may view it.
+    $this->drupalLogout();
+    user_role_change_permissions(
+      RoleInterface::ANONYMOUS_ID,
+      [
+        "create $type_name content" => TRUE,
+        'access content' => TRUE,
+      ]
+    );
+    $test_file = $this->getTestFile('text');
+    $this->drupalGet('node/add/' . $type_name);
+    $edit = ['files[' . $field_name . '_0]' => drupal_realpath($test_file->getFileUri())];
+    $this->drupalPostForm(NULL, $edit, t('Upload'));
+    /** @var \Drupal\file\FileStorageInterface $file_storage */
+    $file_storage = $this->container->get('entity.manager')->getStorage('file');
+    $files = $file_storage->loadByProperties(['uid' => 0]);
+    $this->assertEqual(1, count($files), 'Loaded one anonymous file.');
+    $file = end($files);
+    $this->assertTrue($file->isTemporary(), 'File is temporary.');
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertFalse($usage, 'No file usage found.');
+    $file_url = file_create_url($file->getFileUri());
+    $this->drupalGet($file_url);
+    $this->assertResponse(200, 'Confirmed that the anonymous uploader has access to the temporary file.');
+    // Close the prior connection and remove the session cookie.
+    $this->curlClose();
+    $this->curlCookies = [];
+    $this->cookies = [];
+    $this->drupalGet($file_url);
+    $this->assertResponse(403, 'Confirmed that another anonymous user cannot access the temporary file.');
+
+    // As an anonymous user, create a permanent file, then remove all
+    // references to the file (so that it becomes temporary again) and confirm
+    // that only the session that uploaded it may view it.
+    $test_file = $this->getTestFile('text');
+    $this->drupalGet('node/add/' . $type_name);
+    $edit = [];
+    $edit['title[0][value]'] = $this->randomMachineName();
+    $edit['files[' . $field_name . '_0]'] = drupal_realpath($test_file->getFileUri());
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $new_node = $this->drupalGetNodeByTitle($edit['title[0][value]']);
+    $file_id = $new_node->{$field_name}->target_id;
+    $file = File::load($file_id);
+    $this->assertTrue($file->isPermanent(), 'File is permanent.');
+    // Remove the reference to this file.
+    $new_node->{$field_name} = [];
+    $new_node->save();
+    $file = File::load($file_id);
+    $this->assertTrue($file->isTemporary(), 'File is temporary.');
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertFalse($usage, 'No file usage found.');
+    $file_url = file_create_url($file->getFileUri());
+    $this->drupalGet($file_url);
+    $this->assertResponse(200, 'Confirmed that the anonymous uploader has access to the file whose references were removed.');
+    // Close the prior connection and remove the session cookie.
+    $this->curlClose();
+    $this->curlCookies = [];
+    $this->cookies = [];
+    $this->drupalGet($file_url);
+    $this->assertResponse(403, 'Confirmed that another anonymous user cannot access the file whose references were removed.');
+
+    // As an anonymous user, create a permanent file that is referenced by a
+    // published node and confirm that all anonymous users may view it.
+    $test_file = $this->getTestFile('text');
+    $this->drupalGet('node/add/' . $type_name);
+    $edit = [];
+    $edit['title[0][value]'] = $this->randomMachineName();
+    $edit['files[' . $field_name . '_0]'] = drupal_realpath($test_file->getFileUri());
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $new_node = $this->drupalGetNodeByTitle($edit['title[0][value]']);
+    $file = File::load($new_node->{$field_name}->target_id);
+    $this->assertTrue($file->isPermanent(), 'File is permanent.');
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertTrue($usage, 'File usage found.');
+    $file_url = file_create_url($file->getFileUri());
+    $this->drupalGet($file_url);
+    $this->assertResponse(200, 'Confirmed that the anonymous uploader has access to the permanent file that is referenced by a published node.');
+    // Close the prior connection and remove the session cookie.
+    $this->curlClose();
+    $this->curlCookies = [];
+    $this->cookies = [];
+    $this->drupalGet($file_url);
+    $this->assertResponse(200, 'Confirmed that another anonymous user also has access to the permanent file that is referenced by a published node.');
+
+    // As an anonymous user, create a permanent file that is referenced by an
+    // unpublished node and confirm that no anonymous users may view it (even
+    // the session that uploaded the file) because they cannot view the
+    // unpublished node.
+    $test_file = $this->getTestFile('text');
+    $this->drupalGet('node/add/' . $type_name);
+    $edit = [];
+    $edit['title[0][value]'] = $this->randomMachineName();
+    $edit['files[' . $field_name . '_0]'] = drupal_realpath($test_file->getFileUri());
+    $this->drupalPostForm(NULL, $edit, t('Save'));
+    $new_node = $this->drupalGetNodeByTitle($edit['title[0][value]']);
+    $new_node->setPublished(FALSE);
+    $new_node->save();
+    $file = File::load($new_node->{$field_name}->target_id);
+    $this->assertTrue($file->isPermanent(), 'File is permanent.');
+    $usage = $this->container->get('file.usage')->listUsage($file);
+    $this->assertTrue($usage, 'File usage found.');
+    $file_url = file_create_url($file->getFileUri());
+    $this->drupalGet($file_url);
+    $this->assertResponse(403, 'Confirmed that the anonymous uploader cannot access the permanent file when it is referenced by an unpublished node.');
+    // Close the prior connection and remove the session cookie.
+    $this->curlClose();
+    $this->curlCookies = [];
+    $this->cookies = [];
+    $this->drupalGet($file_url);
+    $this->assertResponse(403, 'Confirmed that another anonymous user cannot access the permanent file when it is referenced by an unpublished node.');
   }
 
 }

--- a/core/modules/file/tests/src/Kernel/AccessTest.php
+++ b/core/modules/file/tests/src/Kernel/AccessTest.php
@@ -85,11 +85,30 @@ class AccessTest extends KernelTestBase {
   }
 
   /**
-   * Tests that the status field is not editable.
+   * Tests file entity field access.
+   *
+   * @see \Drupal\file\FileAccessControlHandler::checkFieldAccess()
    */
-  public function testStatusFieldIsNotEditable() {
+  public function testCheckFieldAccess() {
     \Drupal::currentUser()->setAccount($this->user1);
-    $this->assertFalse($this->file->get('status')->access('edit'));
+    /** @var \Drupal\file\FileInterface $file */
+    $file = File::create([
+      'uri' => 'public://test.png'
+    ]);
+    // While creating a file entity access will be allowed for create-only
+    // fields.
+    $this->assertTrue($file->get('uri')->access('edit'));
+    $this->assertTrue($file->get('filemime')->access('edit'));
+    $this->assertTrue($file->get('filesize')->access('edit'));
+    // Access to the status field is denied whilst creating a file entity.
+    $this->assertFalse($file->get('status')->access('edit'));
+    $file->save();
+    // After saving the entity is no longer new and, therefore, access to
+    // create-only fields and the status field will be denied.
+    $this->assertFalse($file->get('uri')->access('edit'));
+    $this->assertFalse($file->get('filemime')->access('edit'));
+    $this->assertFalse($file->get('filesize')->access('edit'));
+    $this->assertFalse($file->get('status')->access('edit'));
   }
 
   /**

--- a/core/modules/file/tests/src/Kernel/FileItemValidationTest.php
+++ b/core/modules/file/tests/src/Kernel/FileItemValidationTest.php
@@ -45,6 +45,7 @@ class FileItemValidationTest extends KernelTestBase {
       'status' => 1,
     ]);
     $this->user->save();
+    $this->container->get('current_user')->setAccount($this->user);
   }
 
   /**
@@ -85,6 +86,7 @@ class FileItemValidationTest extends KernelTestBase {
     // Test for max filesize.
     $file = File::create([
       'uri' => 'vfs://drupal_root/sites/default/files/test.txt',
+      'uid' => $this->user->id(),
     ]);
     $file->setPermanent();
     $file->save();

--- a/core/tests/Drupal/Tests/Component/Serialization/YamlPeclTest.php
+++ b/core/tests/Drupal/Tests/Component/Serialization/YamlPeclTest.php
@@ -27,6 +27,16 @@ class YamlPeclTest extends YamlTestBase {
   }
 
   /**
+   * Ensures that php object support is disabled.
+   */
+  public function testObjectSupportDisabled() {
+    $object = new \stdClass();
+    $object->foo = 'bar';
+    $this->assertEquals(['O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}'], YamlPecl::decode(YamlPecl::encode([$object])));
+    $this->assertEquals(0, ini_get('yaml.decode_php'));
+  }
+
+  /**
    * Tests decoding YAML node anchors.
    *
    * @covers ::decode

--- a/core/tests/Drupal/Tests/Component/Serialization/YamlSymfonyTest.php
+++ b/core/tests/Drupal/Tests/Component/Serialization/YamlSymfonyTest.php
@@ -63,4 +63,16 @@ class YamlSymfonyTest extends YamlTestBase {
     YamlSymfony::decode('foo: [ads');
   }
 
+  /**
+   * Ensures that php object support is disabled.
+   *
+   * @covers ::encode
+   */
+  public function testObjectSupportDisabled() {
+    $this->setExpectedException(InvalidDataTypeException::class, 'Object support when dumping a YAML file has been disabled.');
+    $object = new \stdClass();
+    $object->foo = 'bar';
+    YamlSymfony::encode([$object]);
+  }
+
 }

--- a/core/tests/Drupal/Tests/Component/Serialization/YamlTest.php
+++ b/core/tests/Drupal/Tests/Component/Serialization/YamlTest.php
@@ -77,6 +77,23 @@ class YamlTest extends UnitTestCase {
   }
 
   /**
+   * Ensures that decoding php objects is similar for PECL and Symfony.
+   *
+   * @requires extension yaml
+   */
+  public function testObjectSupportDisabled() {
+    $object = new \stdClass();
+    $object->foo = 'bar';
+    // In core all Yaml encoding is done via Symfony and it does not support
+    // objects so in order to encode an object we hace to use the PECL
+    // extension.
+    // @see \Drupal\Component\Serialization\Yaml::encode()
+    $yaml = YamlPecl::encode([$object]);
+    $this->assertEquals(['O:8:"stdClass":1:{s:3:"foo";s:3:"bar";}'], YamlPecl::decode($yaml));
+    $this->assertEquals(['!php/object "O:8:\"stdClass\":1:{s:3:\"foo\";s:3:\"bar\";}"'], YamlSymfony::decode($yaml));
+  }
+
+  /**
    * Data provider that lists all YAML files in core.
    */
   public function providerYamlFilesInCore() {

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -1628,6 +1628,7 @@ return array(
     'Drupal\\Core\\Test\\AssertMailTrait' => $baseDir . '/core/lib/Drupal/Core/Test/AssertMailTrait.php',
     'Drupal\\Core\\Test\\FunctionalTestSetupTrait' => $baseDir . '/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php',
     'Drupal\\Core\\Test\\HttpClientMiddleware\\TestHttpClientMiddleware' => $baseDir . '/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php',
+    'Drupal\\Core\\Test\\ObjectSerialization' => $baseDir . '/core/lib/Drupal/Core/Test/ObjectSerialization.php',
     'Drupal\\Core\\Test\\TestDatabase' => $baseDir . '/core/lib/Drupal/Core/Test/TestDatabase.php',
     'Drupal\\Core\\Test\\TestKernel' => $baseDir . '/core/lib/Drupal/Core/Test/TestKernel.php',
     'Drupal\\Core\\Test\\TestRunnerKernel' => $baseDir . '/core/lib/Drupal/Core/Test/TestRunnerKernel.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -1916,6 +1916,7 @@ class ComposerStaticInitDrupal8
         'Drupal\\Core\\Test\\AssertMailTrait' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/AssertMailTrait.php',
         'Drupal\\Core\\Test\\FunctionalTestSetupTrait' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/FunctionalTestSetupTrait.php',
         'Drupal\\Core\\Test\\HttpClientMiddleware\\TestHttpClientMiddleware' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/HttpClientMiddleware/TestHttpClientMiddleware.php',
+        'Drupal\\Core\\Test\\ObjectSerialization' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/ObjectSerialization.php',
         'Drupal\\Core\\Test\\TestDatabase' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/TestDatabase.php',
         'Drupal\\Core\\Test\\TestKernel' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/TestKernel.php',
         'Drupal\\Core\\Test\\TestRunnerKernel' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Test/TestRunnerKernel.php',


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.3.4
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.