### PR TITLE
Update drops-8 to 8.3.6

### DIFF
--- a/core/MAINTAINERS.txt
+++ b/core/MAINTAINERS.txt
@@ -170,10 +170,8 @@ CSS
 - John Albin Wilkins 'JohnAlbin' https://www.drupal.org/u/johnalbin
 
 Database API
-- Larry Garfield 'Crell' https://www.drupal.org/u/crell
 
   MySQL DB driver
-  - Larry Garfield 'Crell' https://www.drupal.org/u/crell
   - David Strauss 'David Strauss' https://www.drupal.org/u/david-strauss
 
   PostgreSQL DB driver
@@ -339,10 +337,9 @@ Render API
 - Moshe Weitzman 'moshe weitzman' https://www.drupal.org/u/moshe-weitzman
 
 Request Processing
-- Larry Garfield 'Crell' https://www.drupal.org/u/crell
+- ?
 
 REST
-- Larry Garfield 'Crell' https://www.drupal.org/u/crell
 - Wim Leers 'Wim Leers' https://www.drupal.org/u/wim-leers
 
 Responsive Image
@@ -351,7 +348,6 @@ Responsive Image
 - Jelle Sebreghts 'Jelle_S' https://www.drupal.org/u/jelle_s
 
 Routing
-- Larry Garfield 'Crell' https://www.drupal.org/u/crell
 - Tim Plunkett 'tim.plunkett' https://www.drupal.org/u/tim.plunkett
 
 Search
@@ -433,6 +429,9 @@ Views
 - Damian Lee 'damiankloip' https://www.drupal.org/u/damiankloip
 - Jess Myrbo 'xjm' https://www.drupal.org/u/xjm
 - Len Swaneveld 'Lendude' https://www.drupal.org/u/lendude
+
+Workflows
+- Sam Becker 'Sam152' https://www.drupal.org/u/sam152
 
 Topic maintainers
 -----------------

--- a/core/core.api.php
+++ b/core/core.api.php
@@ -2530,8 +2530,8 @@ function hook_validation_constraint_alter(array &$definitions) {
  *
  * @section sec_dispatch Dispatching events
  * To dispatch an event, call the
- * \Symfony\Component\EventDispatcher\EventDispatchInterface::dispatch() method
- * on the 'event_dispatcher' service (see the
+ * \Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()
+ * method on the 'event_dispatcher' service (see the
  * @link container Services topic @endlink for more information about how to
  * interact with services). The first argument is the unique event name, which
  * you should normally define as a constant in a separate static class (see

--- a/core/includes/entity.inc
+++ b/core/includes/entity.inc
@@ -531,24 +531,24 @@ function entity_get_display($entity_type, $bundle, $view_mode) {
  *
  * @deprecated as of Drupal 8.0.x, will be removed before Drupal 9.0.0.
  *   If the entity form display is available in configuration use:
- * @code
- *   \Drupal::entityTypeManager()
- *     ->getStorage('entity_form_display')
- *     ->load($entity_type . '.' . $bundle . '.' . $form_mode);
- * @endcode
+ *   @code
+ *     \Drupal::entityTypeManager()
+ *       ->getStorage('entity_form_display')
+ *       ->load($entity_type . '.' . $bundle . '.' . $form_mode);
+ *   @endcode
  *   When the entity form display is not available in configuration, you can
  *   create a new EntityFormDisplay object using:
- * @code
- * $values = array(
- *  'targetEntityType' => $entity_type,
- *  'bundle' => $bundle,
- *  'mode' => $form_mode,
- *  'status' => TRUE,
- * );
- * \Drupal::entityTypeManager()
- *   ->getStorage('entity_form_display')
- *   ->create($values);
- * @endcode
+ *   @code
+ *   $values = array(
+ *    'targetEntityType' => $entity_type,
+ *    'bundle' => $bundle,
+ *    'mode' => $form_mode,
+ *    'status' => TRUE,
+ *   );
+ *   \Drupal::entityTypeManager()
+ *     ->getStorage('entity_form_display')
+ *     ->create($values);
+ *   @endcode
  *
  * @see \Drupal\Core\Entity\EntityStorageInterface::create()
  * @see \Drupal\Core\Entity\EntityStorageInterface::load()

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.3.5';
+  const VERSION = '8.3.6';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Field/FieldConfigBase.php
+++ b/core/lib/Drupal/Core/Field/FieldConfigBase.php
@@ -181,6 +181,14 @@ abstract class FieldConfigBase extends ConfigEntityBase implements FieldConfigIn
   protected $constraints = [];
 
   /**
+   * Array of property constraint options keyed by property ID. The values are
+   * associative array of constraint options keyed by constraint plugin ID.
+   *
+   * @var array[]
+   */
+  protected $propertyConstraints = [];
+
+  /**
    * {@inheritdoc}
    */
   public function id() {
@@ -515,7 +523,20 @@ abstract class FieldConfigBase extends ConfigEntityBase implements FieldConfigIn
     if (!isset($this->itemDefinition)) {
       $this->itemDefinition = FieldItemDataDefinition::create($this)
         ->setSettings($this->getSettings());
+
+      // Add any custom property constraints, overwriting as required.
+      $item_constraints = $this->itemDefinition->getConstraint('ComplexData') ?: [];
+      foreach ($this->propertyConstraints as $name => $constraints) {
+        if (isset($item_constraints[$name])) {
+          $item_constraints[$name] = $constraints + $item_constraints[$name];
+        }
+        else {
+          $item_constraints[$name] = $constraints;
+        }
+        $this->itemDefinition->addConstraint('ComplexData', $item_constraints);
+      }
     }
+
     return $this->itemDefinition;
   }
 
@@ -546,9 +567,12 @@ abstract class FieldConfigBase extends ConfigEntityBase implements FieldConfigIn
    * {@inheritdoc}
    */
   public function setPropertyConstraints($name, array $constraints) {
-    $item_constraints = $this->getItemDefinition()->getConstraints();
-    $item_constraints['ComplexData'][$name] = $constraints;
-    $this->getItemDefinition()->setConstraints($item_constraints);
+    $this->propertyConstraints[$name] = $constraints;
+
+    // Reset the field item definition so the next time it is instantiated it
+    // will receive the new constraints.
+    $this->itemDefinition = NULL;
+
     return $this;
   }
 
@@ -556,15 +580,14 @@ abstract class FieldConfigBase extends ConfigEntityBase implements FieldConfigIn
    * {@inheritdoc}
    */
   public function addPropertyConstraints($name, array $constraints) {
-    $item_constraints = $this->getItemDefinition()->getConstraint('ComplexData') ?: [];
-    if (isset($item_constraints[$name])) {
-      // Add the new property constraints, overwriting as required.
-      $item_constraints[$name] = $constraints + $item_constraints[$name];
+    foreach ($constraints as $constraint_name => $options) {
+      $this->propertyConstraints[$name][$constraint_name] = $options;
     }
-    else {
-      $item_constraints[$name] = $constraints;
-    }
-    $this->getItemDefinition()->addConstraint('ComplexData', $item_constraints);
+
+    // Reset the field item definition so the next time it is instantiated it
+    // will receive the new constraints.
+    $this->itemDefinition = NULL;
+
     return $this;
   }
 

--- a/core/modules/field/tests/modules/field_test/field_test.module
+++ b/core/modules/field/tests/modules/field_test/field_test.module
@@ -151,15 +151,18 @@ function field_test_entity_extra_field_info_alter(&$info) {
  * Implements hook_entity_bundle_field_info_alter().
  */
 function field_test_entity_bundle_field_info_alter(&$fields, EntityTypeInterface $entity_type, $bundle) {
-  if (($field_name = \Drupal::state()->get('field_test_set_constraint', FALSE)) && $entity_type->id() == 'entity_test' && $bundle == 'entity_test' && !empty($fields[$field_name])) {
+  if (($field_name = \Drupal::state()->get('field_test_constraint', FALSE)) && $entity_type->id() == 'entity_test' && $bundle == 'entity_test' && !empty($fields[$field_name])) {
+    // Set a property constraint using
+    // \Drupal\Core\Field\FieldConfigInterface::setPropertyConstraints().
     $fields[$field_name]->setPropertyConstraints('value', [
-      'Range' => [
-        'min' => 0,
-        'max' => 32,
+      'TestField' => [
+        'value' => -2,
+        'message' => t('%name does not accept the value @value.', ['%name' => $field_name, '@value' => -2]),
       ],
     ]);
-  }
-  if (($field_name = \Drupal::state()->get('field_test_add_constraint', FALSE)) && $entity_type->id() == 'entity_test' && $bundle == 'entity_test' && !empty($fields[$field_name])) {
+
+    // Add a property constraint using
+    // \Drupal\Core\Field\FieldConfigInterface::addPropertyConstraints().
     $fields[$field_name]->addPropertyConstraints('value', [
       'Range' => [
         'min' => 0,

--- a/core/modules/field/tests/src/Kernel/FieldCrudTest.php
+++ b/core/modules/field/tests/src/Kernel/FieldCrudTest.php
@@ -12,6 +12,8 @@ use Drupal\field\Entity\FieldConfig;
 /**
  * Create field entities by attaching fields to entities.
  *
+ * @coversDefaultClass \Drupal\Core\Field\FieldConfigBase
+ *
  * @group field
  */
 class FieldCrudTest extends FieldKernelTestBase {
@@ -64,10 +66,6 @@ class FieldCrudTest extends FieldKernelTestBase {
    * Test the creation of a field.
    */
   public function testCreateField() {
-    // Set a state flag so that field_test.module knows to add an in-memory
-    // constraint for this field.
-    \Drupal::state()->set('field_test_add_constraint', $this->fieldStorage->getName());
-    /** @var \Drupal\Core\Field\FieldConfigInterface $field */
     $field = FieldConfig::create($this->fieldDefinition);
     $field->save();
 
@@ -100,17 +98,6 @@ class FieldCrudTest extends FieldKernelTestBase {
     // Check that the denormalized 'field_type' was properly written.
     $this->assertEqual($config['field_type'], $this->fieldStorageDefinition['type']);
 
-    // Test constraints are applied. A Range constraint is added dynamically to
-    // limit the field to values between 0 and 32.
-    // @see field_test_entity_bundle_field_info_alter()
-    $this->doFieldValidationTests();
-
-    // Test FieldConfigBase::setPropertyConstraints().
-    \Drupal::state()->set('field_test_set_constraint', $this->fieldStorage->getName());
-    \Drupal::state()->set('field_test_add_constraint', FALSE);
-    \Drupal::entityManager()->clearCachedFieldDefinitions();
-    $this->doFieldValidationTests();
-
     // Guarantee that the field/bundle combination is unique.
     try {
       FieldConfig::create($this->fieldDefinition)->save();
@@ -131,6 +118,81 @@ class FieldCrudTest extends FieldKernelTestBase {
     }
 
     // TODO: test other failures.
+  }
+
+  /**
+   * Tests setting and adding property constraints to a configurable field.
+   *
+   * @covers ::setPropertyConstraints
+   * @covers ::addPropertyConstraints
+   */
+  public function testFieldPropertyConstraints() {
+    $field = FieldConfig::create($this->fieldDefinition);
+    $field->save();
+    $field_name = $this->fieldStorage->getName();
+
+    // Test that constraints are applied to configurable fields. A TestField and
+    // a Range constraint are added dynamically to limit the field to values
+    // between 0 and 32.
+    // @see field_test_entity_bundle_field_info_alter()
+    \Drupal::state()->set('field_test_constraint', $field_name);
+
+    // Clear the field definitions cache so the new constraints added by
+    // field_test_entity_bundle_field_info_alter() are taken into consideration.
+    \Drupal::service('entity_field.manager')->clearCachedFieldDefinitions();
+
+    // Test the newly added property constraints in the same request as when the
+    // caches were cleared. This will test the field definitions that are stored
+    // in the static cache of
+    // \Drupal\Core\Entity\EntityFieldManager::getFieldDefinitions().
+    $this->doFieldPropertyConstraintsTests();
+
+    // In order to test a real-world scenario where the property constraints are
+    // only stored in the persistent cache of
+    // \Drupal\Core\Entity\EntityFieldManager::getFieldDefinitions(), we need to
+    // simulate a new request by removing the 'entity_field.manager' service,
+    // thus forcing it to be re-initialized without static caches.
+    \Drupal::getContainer()->set('entity_field.manager', NULL);
+
+    // This will test the field definitions that are stored in the persistent
+    // cache by \Drupal\Core\Entity\EntityFieldManager::getFieldDefinitions().
+    $this->doFieldPropertyConstraintsTests();
+  }
+
+  /**
+   * Tests configurable field validation.
+   *
+   * @see field_test_entity_bundle_field_info_alter()
+   */
+  protected function doFieldPropertyConstraintsTests() {
+    $field_name = $this->fieldStorage->getName();
+
+    // Check that a valid value (not -2 and between 0 and 32) doesn't trigger
+    // any violation.
+    $entity = EntityTest::create();
+    $entity->set($field_name, 1);
+    $violations = $entity->validate();
+    $this->assertCount(0, $violations, 'No violations found when in-range value passed.');
+
+    // Check that a value that is specifically restricted triggers both
+    // violations.
+    $entity->set($field_name, -2);
+    $violations = $entity->validate();
+    $this->assertCount(2, $violations, 'Two violations found when using a null and outside the range value.');
+
+    $this->assertEquals($field_name . '.0.value', $violations[0]->getPropertyPath());
+    $this->assertEquals(t('%name does not accept the value @value.', ['%name' => $field_name, '@value' => -2]), $violations[0]->getMessage());
+
+    $this->assertEquals($field_name . '.0.value', $violations[1]->getPropertyPath());
+    $this->assertEquals(t('This value should be %limit or more.', ['%limit' => 0]), $violations[1]->getMessage());
+
+    // Check that a value that is not specifically restricted but outside the
+    // range triggers the expected violation.
+    $entity->set($field_name, 33);
+    $violations = $entity->validate();
+    $this->assertCount(1, $violations, 'Violations found when using value outside the range.');
+    $this->assertEquals($field_name . '.0.value', $violations[0]->getPropertyPath());
+    $this->assertEquals(t('This value should be %limit or less.', ['%limit' => 32]), $violations[0]->getMessage());
   }
 
   /**
@@ -278,26 +340,6 @@ class FieldCrudTest extends FieldKernelTestBase {
     $field_2->save();
     $this->container->get('entity.manager')->getStorage('field_config')->delete([$field, $field_2]);
     $this->assertFalse(FieldStorageConfig::loadByName('entity_test', $field_storage->getName()));
-  }
-
-  /**
-   * Tests configurable field validation.
-   *
-   * @see field_test_entity_bundle_field_info_alter()
-   */
-  protected function doFieldValidationTests() {
-    $entity = EntityTest::create();
-    $entity->set($this->fieldStorage->getName(), 1);
-    $violations = $entity->validate();
-    $this->assertEqual(count($violations), 0, 'No violations found when in-range value passed.');
-
-    $entity->set($this->fieldStorage->getName(), 33);
-    $violations = $entity->validate();
-    $this->assertEqual(count($violations), 1, 'Violations found when using value outside the range.');
-    $this->assertEqual($violations[0]->getPropertyPath(), $this->fieldStorage->getName() . '.0.value');
-    $this->assertEqual($violations[0]->getMessage(), t('This value should be %limit or less.', [
-      '%limit' => 32,
-    ]));
   }
 
 }

--- a/core/modules/locale/tests/src/Functional/LocaleTranslationUiTest.php
+++ b/core/modules/locale/tests/src/Functional/LocaleTranslationUiTest.php
@@ -44,7 +44,7 @@ class LocaleTranslationUiTest extends BrowserTestBase {
     // Code for the language.
     $langcode = 'xx';
     // The English name for the language. This will be translated.
-    $name = $this->randomMachineName(16);
+    $name = 'cucurbitaceae';
     // This will be the translation of $name.
     $translation = $this->randomMachineName(16);
     $translation_to_en = $this->randomMachineName(16);

--- a/core/modules/migrate_drupal/src/Plugin/MigrateCckFieldPluginManagerInterface.php
+++ b/core/modules/migrate_drupal/src/Plugin/MigrateCckFieldPluginManagerInterface.php
@@ -11,5 +11,7 @@ instead.', E_USER_DEPRECATED);
  *
  * @deprecated in Drupal 8.3.x, to be removed before Drupal 9.0.x. Use
  *   \Drupal\migrate_drupal\Plugin\MigrateFieldPluginManagerInterface instead.
+ *
+ * @see https://www.drupal.org/node/2751897
  */
 interface MigrateCckFieldPluginManagerInterface extends MigrateFieldPluginManagerInterface { }

--- a/core/modules/outside_in/css/outside_in.motion.css
+++ b/core/modules/outside_in/css/outside_in.motion.css
@@ -26,19 +26,3 @@
   -moz-transition: all .7s ease;
   transition: all .7s ease;
 }
-
-/* Transition the position of the toolbar. */
-.toolbar-fixed,
-.toolbar-tray-open {
-  -webkit-transition: all .5s ease;
-  -moz-transition: all .5s ease;
-  transition: all .5s ease;
-}
-
-/* Transition the administration tray.
-#toolbar-administration,
-#toolbar-administration * {
-  -webkit-transition: all .7s ease;
-  -moz-transition: all .7s ease;
-  transition: all .7s ease;
-}*/

--- a/core/modules/outside_in/css/outside_in.theme.css
+++ b/core/modules/outside_in/css/outside_in.theme.css
@@ -9,7 +9,7 @@
 
 /* Style the edit mode toolbar and tabs. */
 #toolbar-bar.js-outside-in-edit-mode {
-  background-color: #fff;
+  background-image: linear-gradient(to bottom,#0c97ed,#1f86c7);
 }
 .js-outside-in-edit-mode .toolbar-item:not(.toolbar-icon-edit) {
   color: #999;

--- a/core/modules/outside_in/src/Block/BlockEntityOffCanvasForm.php
+++ b/core/modules/outside_in/src/Block/BlockEntityOffCanvasForm.php
@@ -44,7 +44,7 @@ class BlockEntityOffCanvasForm extends BlockForm {
     }
     $form['advanced_link'] = [
       '#type' => 'link',
-      '#title' => $this->t('Advanced options'),
+      '#title' => $this->t('Advanced block options'),
       '#url' => $this->entity->toUrl('edit-form', ['query' => $query]),
       '#weight' => 1000,
     ];
@@ -52,6 +52,18 @@ class BlockEntityOffCanvasForm extends BlockForm {
     // Remove the ID and region elements.
     unset($form['id'], $form['region'], $form['settings']['admin_label']);
 
+    if (isset($form['settings']['label_display']) && isset($form['settings']['label'])) {
+      // Only show the label input if the label will be shown on the page.
+      $form['settings']['label_display']['#weight'] = -100;
+      $form['settings']['label']['#states']['visible'] = [
+        ':input[name="settings[label_display]"]' => ['checked' => TRUE],
+      ];
+
+      // Relabel to "Block title" because on the front-end this may be confused
+      // with page title.
+      $form['settings']['label']['#title'] = $this->t("Block title");
+      $form['settings']['label_display']['#title'] = $this->t("Display block title");
+    }
     return $form;
   }
 

--- a/core/modules/outside_in/templates/outside-in-page-wrapper.html.twig
+++ b/core/modules/outside_in/templates/outside-in-page-wrapper.html.twig
@@ -5,7 +5,13 @@
  *
  * For consistent wrapping to {{ page }} render in all themes. The
  * "data-off-canvas-main-canvas" attribute is required by the off-canvas dialog.
- * It cannot be removed without breaking the off-canvas dialog functionality.
+ * This is used by the outside_in/drupal.off_canvas library to select the
+ * "main canvas" page element as opposed to the "off canvas" which is the tray
+ * itself. The "main canvas" element must be resized according to the width of
+ * the "off canvas" tray so that no portion of the "main canvas" is obstructed
+ * by the tray. The tray can vary in width when opened and can be resized by the
+ * user. The "data-off-canvas-main-canvas" attribute cannot be removed without
+ * breaking the off-canvas dialog functionality.
  *
  * Available variables:
  * - children: Contains the child elements of the page.

--- a/core/modules/outside_in/tests/src/FunctionalJavascript/OutsideInBlockFormTest.php
+++ b/core/modules/outside_in/tests/src/FunctionalJavascript/OutsideInBlockFormTest.php
@@ -16,6 +16,8 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
 
   const TOOLBAR_EDIT_LINK_SELECTOR = '#toolbar-bar div.contextual-toolbar-tab button';
 
+  const LABEL_INPUT_SELECTOR = 'input[data-drupal-selector="edit-settings-label"]';
+
   /**
    * {@inheritdoc}
    */
@@ -83,7 +85,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
           $this->waitForNoElement("#toolbar-administration a.is-active");
         }
         $page->find('css', $toolbar_item)->click();
-        $web_assert->waitForElementVisible('css', "{$toolbar_item}.is-active");
+        $this->assertElementVisibleAfterWait('css', "{$toolbar_item}.is-active");
       }
       $this->enableEditMode();
       if (isset($toolbar_item)) {
@@ -92,9 +94,15 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
       $this->openBlockForm($block_selector);
       switch ($block_plugin) {
         case 'system_powered_by_block':
+          // Confirm "Display Title" is not checked.
+          $web_assert->checkboxNotChecked('settings[label_display]');
+          // Confirm Title is not visible.
+          $this->assertEquals($this->isLabelInputVisible(), FALSE, 'Label is not visible');
+          $page->checkField('settings[label_display]');
+          $this->assertEquals($this->isLabelInputVisible(), TRUE, 'Label is visible');
           // Fill out form, save the form.
           $page->fillField('settings[label]', $new_page_text);
-          $page->checkField('settings[label_display]');
+
           break;
 
         case 'system_branding_block':
@@ -195,8 +203,19 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
    */
   protected function assertOffCanvasBlockFormIsValid() {
     $web_assert = $this->assertSession();
+    // Confirm that Block title display label has been changed.
+    $web_assert->elementTextContains('css', '.form-item-settings-label-display label', 'Display block title');
+    // Confirm Block title label is shown if checkbox is checked.
+    if ($this->getSession()->getPage()->find('css', 'input[name="settings[label_display]"]')->isChecked()) {
+      $this->assertEquals($this->isLabelInputVisible(), TRUE, 'Label is visible');
+      $web_assert->elementTextContains('css', '.form-item-settings-label label', 'Block title');
+    }
+    else {
+      $this->assertEquals($this->isLabelInputVisible(), FALSE, 'Label is not visible');
+    }
+
     // Check that common block form elements exist.
-    $web_assert->elementExists('css', 'input[data-drupal-selector="edit-settings-label"]');
+    $web_assert->elementExists('css', static::LABEL_INPUT_SELECTOR);
     $web_assert->elementExists('css', 'input[data-drupal-selector="edit-settings-label-display"]');
     // Check that advanced block form elements do not exist.
     $web_assert->elementNotExists('css', 'input[data-drupal-selector="edit-visibility-request-path-pages"]');
@@ -257,7 +276,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
         $this->drupalGet('node/' . $node->id());
         // Waiting for Toolbar module.
         // @todo Remove the hack after https://www.drupal.org/node/2542050.
-        $web_assert->waitForElementVisible('css', '.toolbar-fixed');
+        $this->assertElementVisibleAfterWait('css', '.toolbar-fixed');
         // Waiting for Toolbar animation.
         $web_assert->assertWaitOnAjaxRequest();
         // The 2nd page load we should already be in edit mode.
@@ -266,7 +285,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
         }
         // In Edit mode clicking field should open QuickEdit toolbar.
         $page->find('css', $body_selector)->click();
-        $web_assert->waitForElementVisible('css', $quick_edit_selector);
+        $this->assertElementVisibleAfterWait('css', $quick_edit_selector);
 
         $this->disableEditMode();
         // Exiting Edit mode should close QuickEdit toolbar.
@@ -277,7 +296,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
         $this->enableEditMode();
         $this->openBlockForm($block_selector);
         $page->find('css', $body_selector)->click();
-        $web_assert->waitForElementVisible('css', $quick_edit_selector);
+        $this->assertElementVisibleAfterWait('css', $quick_edit_selector);
         // Off-canvas dialog should be closed when opening QuickEdit toolbar.
         $this->waitForOffCanvasToClose();
 
@@ -291,7 +310,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
       $this->disableEditMode();
       // Open QuickEdit toolbar before going into Edit mode.
       $this->clickContextualLink($node_selector, "Quick edit");
-      $web_assert->waitForElementVisible('css', $quick_edit_selector);
+      $this->assertElementVisibleAfterWait('css', $quick_edit_selector);
       // Open off-canvas and enter Edit mode via contextual link.
       $this->clickContextualLink($block_selector, "Quick edit");
       $this->waitForOffCanvasToOpen();
@@ -300,7 +319,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
       // Open QuickEdit toolbar via contextual link while in Edit mode.
       $this->clickContextualLink($node_selector, "Quick edit", FALSE);
       $this->waitForOffCanvasToClose();
-      $web_assert->waitForElementVisible('css', $quick_edit_selector);
+      $this->assertElementVisibleAfterWait('css', $quick_edit_selector);
       $this->disableEditMode();
     }
   }
@@ -467,6 +486,16 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
    */
   public function getBlockSelector(Block $block) {
     return '#block-' . $block->id();
+  }
+
+  /**
+   * Determines if the label input is visible.
+   *
+   * @return bool
+   *   TRUE if the label is visible, FALSE if it is not.
+   */
+  protected function isLabelInputVisible() {
+    return $this->getSession()->getPage()->find('css', static::LABEL_INPUT_SELECTOR)->isVisible();
   }
 
 }

--- a/core/modules/outside_in/tests/src/FunctionalJavascript/OutsideInJavascriptTestBase.php
+++ b/core/modules/outside_in/tests/src/FunctionalJavascript/OutsideInJavascriptTestBase.php
@@ -42,7 +42,7 @@ abstract class OutsideInJavascriptTestBase extends JavascriptTestBase {
   protected function waitForOffCanvasToOpen() {
     $web_assert = $this->assertSession();
     $web_assert->assertWaitOnAjaxRequest();
-    $web_assert->waitForElementVisible('css', '#drupal-off-canvas');
+    $this->assertElementVisibleAfterWait('css', '#drupal-off-canvas');
   }
 
   /**
@@ -125,7 +125,7 @@ abstract class OutsideInJavascriptTestBase extends JavascriptTestBase {
     $web_assert = $this->assertSession();
     // Waiting for Toolbar module.
     // @todo Remove the hack after https://www.drupal.org/node/2542050.
-    $web_assert->waitForElementVisible('css', '.toolbar-fixed');
+    $this->assertElementVisibleAfterWait('css', '.toolbar-fixed');
     // Waiting for Toolbar animation.
     $web_assert->assertWaitOnAjaxRequest();
   }
@@ -138,6 +138,21 @@ abstract class OutsideInJavascriptTestBase extends JavascriptTestBase {
    */
   protected function getTestThemes() {
     return ['bartik', 'stark', 'classy', 'stable'];
+  }
+
+  /**
+   * Asserts the specified selector is visible after a wait.
+   *
+   * @param string $selector
+   *   The selector engine name. See ElementInterface::findAll() for the
+   *   supported selectors.
+   * @param string|array $locator
+   *   The selector locator.
+   * @param int $timeout
+   *   (Optional) Timeout in milliseconds, defaults to 10000.
+   */
+  protected function assertElementVisibleAfterWait($selector, $locator, $timeout = 10000) {
+    $this->assertNotEmpty($this->assertSession()->waitForElementVisible($selector, $locator, $timeout));
   }
 
 }

--- a/core/modules/simpletest/tests/src/Unit/TestDiscoveryTest.php
+++ b/core/modules/simpletest/tests/src/Unit/TestDiscoveryTest.php
@@ -1,10 +1,5 @@
 <?php
 
-/**
- * @file
- * Contains \Drupal\Tests\simpletest\Unit\TestInfoParsingTest.
- */
-
 namespace Drupal\Tests\simpletest\Unit;
 
 use Composer\Autoload\ClassLoader;
@@ -19,7 +14,7 @@ use org\bovigo\vfs\vfsStream;
  * @coversDefaultClass \Drupal\simpletest\TestDiscovery
  * @group simpletest
  */
-class TestInfoParsingTest extends UnitTestCase {
+class TestDiscoveryTest extends UnitTestCase {
 
   /**
    * @covers ::getTestInfo
@@ -35,13 +30,13 @@ class TestInfoParsingTest extends UnitTestCase {
     $tests[] = [
       // Expected result.
       [
-        'name' => 'Drupal\Tests\simpletest\Unit\TestInfoParsingTest',
+        'name' => 'Drupal\Tests\simpletest\Unit\TestDiscoveryTest',
         'group' => 'simpletest',
         'description' => 'Tests \Drupal\simpletest\TestDiscovery.',
         'type' => 'PHPUnit-Unit',
       ],
       // Classname.
-      'Drupal\Tests\simpletest\Unit\TestInfoParsingTest',
+      'Drupal\Tests\simpletest\Unit\TestDiscoveryTest',
     ];
 
     // A core unit test.
@@ -366,26 +361,6 @@ EOF;
     ], $result);
   }
 
-}
-
-class TestTestDiscovery extends TestDiscovery {
-
-  /**
-   * @var \Drupal\Core\Extension\Extension[]
-   */
-  protected $extensions = [];
-
-  public function setExtensions(array $extensions) {
-    $this->extensions = $extensions;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  protected function getExtensions() {
-    return $this->extensions;
-  }
-
   /**
    * @covers ::getPhpunitTestSuite
    * @dataProvider providerTestGetPhpunitTestSuite
@@ -409,6 +384,26 @@ class TestTestDiscovery extends TestDiscovery {
     $data['core-functionaljavascripttest'] = ['\Drupal\FunctionalJavascriptTests\ExampleTest', 'FunctionalJavascript'];
 
     return $data;
+  }
+
+}
+
+class TestTestDiscovery extends TestDiscovery {
+
+  /**
+   * @var \Drupal\Core\Extension\Extension[]
+   */
+  protected $extensions = [];
+
+  public function setExtensions(array $extensions) {
+    $this->extensions = $extensions;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getExtensions() {
+    return $this->extensions;
   }
 
 }

--- a/core/modules/views_ui/src/Tests/ViewEditTest.php
+++ b/core/modules/views_ui/src/Tests/ViewEditTest.php
@@ -64,6 +64,12 @@ class ViewEditTest extends UITestBase {
     $this->assertIdentical($displays['test_1']['id'], 'test_1', 'New display ID matches the display ID key.');
     $this->assertFalse(array_key_exists('attachment_1', $displays), 'Old display ID not found.');
 
+    // Set to the same machine name and save the View.
+    $edit = ['display_id' => 'test_1'];
+    $this->drupalPostForm('admin/structure/views/nojs/display/test_view/test_1/display_id', $edit, 'Apply');
+    $this->drupalPostForm(NULL, [], 'Save');
+    $this->assertLink(t('test_1'));
+
     // Test the form validation with invalid IDs.
     $machine_name_edit_url = 'admin/structure/views/nojs/display/test_view/test_1/display_id';
     $error_text = t('Display name must be letters, numbers, or underscores only.');

--- a/core/modules/views_ui/src/ViewEditForm.php
+++ b/core/modules/views_ui/src/ViewEditForm.php
@@ -275,7 +275,7 @@ class ViewEditForm extends ViewFormBase {
 
     // Rename display ids if needed.
     foreach ($executable->displayHandlers as $id => $display) {
-      if (!empty($display->display['new_id']) && empty($display->display['deleted'])) {
+      if (!empty($display->display['new_id']) && $display->display['new_id'] !== $display->display['id'] && empty($display->display['deleted'])) {
         $new_id = $display->display['new_id'];
         $display->display['id'] = $new_id;
         unset($display->display['new_id']);
@@ -289,6 +289,9 @@ class ViewEditForm extends ViewFormBase {
           'view' => $view->id(),
           'display_id' => $new_id,
         ]);
+      }
+      elseif (isset($display->display['new_id'])) {
+        unset($display->display['new_id']);
       }
     }
     $view->set('display', $displays);

--- a/core/tests/Drupal/Tests/Core/Cache/CacheCollectorTest.php
+++ b/core/tests/Drupal/Tests/Core/Cache/CacheCollectorTest.php
@@ -327,7 +327,8 @@ class CacheCollectorTest extends UnitTestCase {
     // invalidation.
     $this->cacheBackend->expects($this->at(0))
       ->method('get')
-      ->with($this->cid, TRUE);
+      ->with($this->cid, TRUE)
+      ->will($this->returnValue($cache));
     $this->cacheBackend->expects($this->once())
       ->method('set')
       ->with($this->cid, [], Cache::PERMANENT, []);


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.3.6
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.