### PR TITLE
Update drops-8 to 8.5.1

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.5.0';
+  const VERSION = '8.5.1';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/DrupalKernel.php
+++ b/core/lib/Drupal/Core/DrupalKernel.php
@@ -20,6 +20,7 @@ use Drupal\Core\File\MimeType\MimeTypeGuesser;
 use Drupal\Core\Http\TrustedHostsRequestFactory;
 use Drupal\Core\Installer\InstallerRedirectTrait;
 use Drupal\Core\Language\Language;
+use Drupal\Core\Security\RequestSanitizer;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Test\TestDatabase;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
@@ -542,6 +543,12 @@ class DrupalKernel implements DrupalKernelInterface, TerminableInterface {
    * {@inheritdoc}
    */
   public function preHandle(Request $request) {
+    // Sanitize the request.
+    $request = RequestSanitizer::sanitize(
+      $request,
+      (array) Settings::get(RequestSanitizer::SANITIZE_WHITELIST, []),
+      (bool) Settings::get(RequestSanitizer::SANITIZE_LOG, FALSE)
+    );
 
     $this->loadLegacyIncludes();
 

--- a/core/lib/Drupal/Core/Security/RequestSanitizer.php
+++ b/core/lib/Drupal/Core/Security/RequestSanitizer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\Core\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Sanitizes user input.
+ */
+class RequestSanitizer {
+
+  /**
+   * Request attribute to mark the request as sanitized.
+   */
+  const SANITIZED = '_drupal_request_sanitized';
+
+  /**
+   * The name of the setting that configures the whitelist.
+   */
+  const SANITIZE_WHITELIST = 'sanitize_input_whitelist';
+
+  /**
+   * The name of the setting that determines if sanitized keys are logged.
+   */
+  const SANITIZE_LOG = 'sanitize_input_logging';
+
+  /**
+   * Strips dangerous keys from user input.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The incoming request to sanitize.
+   * @param string[] $whitelist
+   *   An array of keys to whitelist as safe. See default.settings.php.
+   * @param bool $log_sanitized_keys
+   *   (optional) Set to TRUE to log an keys that are sanitized.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   The sanitized request.
+   */
+  public static function sanitize(Request $request, $whitelist, $log_sanitized_keys = FALSE) {
+    if (!$request->attributes->get(self::SANITIZED, FALSE)) {
+      // Process query string parameters.
+      $get_sanitized_keys = [];
+      $request->query->replace(static::stripDangerousValues($request->query->all(), $whitelist, $get_sanitized_keys));
+      if ($log_sanitized_keys && !empty($get_sanitized_keys)) {
+        trigger_error(sprintf('Potentially unsafe keys removed from query string parameters (GET): %s', implode(', ', $get_sanitized_keys)));
+      }
+
+      // Request body parameters.
+      $post_sanitized_keys = [];
+      $request->request->replace(static::stripDangerousValues($request->request->all(), $whitelist, $post_sanitized_keys));
+      if ($log_sanitized_keys && !empty($post_sanitized_keys)) {
+        trigger_error(sprintf('Potentially unsafe keys removed from request body parameters (POST): %s', implode(', ', $post_sanitized_keys)));
+      }
+
+      // Cookie parameters.
+      $cookie_sanitized_keys = [];
+      $request->cookies->replace(static::stripDangerousValues($request->cookies->all(), $whitelist, $cookie_sanitized_keys));
+      if ($log_sanitized_keys && !empty($cookie_sanitized_keys)) {
+        trigger_error(sprintf('Potentially unsafe keys removed from cookie parameters: %s', implode(', ', $cookie_sanitized_keys)));
+      }
+
+      if (!empty($get_sanitized_keys) || !empty($post_sanitized_keys) || !empty($cookie_sanitized_keys)) {
+        $request->overrideGlobals();
+      }
+      $request->attributes->set(self::SANITIZED, TRUE);
+    }
+    return $request;
+  }
+
+  /**
+   * Strips dangerous keys from $input.
+   *
+   * @param mixed $input
+   *   The input to sanitize.
+   * @param string[] $whitelist
+   *   An array of keys to whitelist as safe.
+   * @param string[] $sanitized_keys
+   *   An array of keys that have been removed.
+   *
+   * @return mixed
+   *   The sanitized input.
+   */
+  protected static function stripDangerousValues($input, array $whitelist, array &$sanitized_keys) {
+    if (is_array($input)) {
+      foreach ($input as $key => $value) {
+        if ($key !== '' && $key[0] === '#' && !in_array($key, $whitelist, TRUE)) {
+          unset($input[$key]);
+          $sanitized_keys[] = $key;
+        }
+        else {
+          $input[$key] = static::stripDangerousValues($input[$key], $whitelist, $sanitized_keys);
+        }
+      }
+    }
+    return $input;
+  }
+
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -1632,6 +1632,7 @@ return array(
     'Drupal\\Core\\Routing\\UrlGeneratorInterface' => $baseDir . '/core/lib/Drupal/Core/Routing/UrlGeneratorInterface.php',
     'Drupal\\Core\\Routing\\UrlGeneratorTrait' => $baseDir . '/core/lib/Drupal/Core/Routing/UrlGeneratorTrait.php',
     'Drupal\\Core\\Routing\\UrlMatcher' => $baseDir . '/core/lib/Drupal/Core/Routing/UrlMatcher.php',
+    'Drupal\\Core\\Security\\RequestSanitizer' => $baseDir . '/core/lib/Drupal/Core/Security/RequestSanitizer.php',
     'Drupal\\Core\\Serialization\\Yaml' => $baseDir . '/core/lib/Drupal/Core/Serialization/Yaml.php',
     'Drupal\\Core\\Session\\AccountInterface' => $baseDir . '/core/lib/Drupal/Core/Session/AccountInterface.php',
     'Drupal\\Core\\Session\\AccountProxy' => $baseDir . '/core/lib/Drupal/Core/Session/AccountProxy.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -2036,6 +2036,7 @@ class ComposerStaticInitDrupal8
         'Drupal\\Core\\Routing\\UrlGeneratorInterface' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Routing/UrlGeneratorInterface.php',
         'Drupal\\Core\\Routing\\UrlGeneratorTrait' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Routing/UrlGeneratorTrait.php',
         'Drupal\\Core\\Routing\\UrlMatcher' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Routing/UrlMatcher.php',
+        'Drupal\\Core\\Security\\RequestSanitizer' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Security/RequestSanitizer.php',
         'Drupal\\Core\\Serialization\\Yaml' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Serialization/Yaml.php',
         'Drupal\\Core\\Session\\AccountInterface' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Session/AccountInterface.php',
         'Drupal\\Core\\Session\\AccountProxy' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Session/AccountProxy.php',


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.5.1
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.