### PR TITLE
Update drops-8 to 8.3.9

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.3.8';
+  const VERSION = '8.3.9';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -81,7 +81,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.3.7';
+  const VERSION = '8.3.8';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/DrupalKernel.php
+++ b/core/lib/Drupal/Core/DrupalKernel.php
@@ -19,6 +19,7 @@ use Drupal\Core\File\MimeType\MimeTypeGuesser;
 use Drupal\Core\Http\TrustedHostsRequestFactory;
 use Drupal\Core\Installer\InstallerRedirectTrait;
 use Drupal\Core\Language\Language;
+use Drupal\Core\Security\RequestSanitizer;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\Test\TestDatabase;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
@@ -541,6 +542,12 @@ class DrupalKernel implements DrupalKernelInterface, TerminableInterface {
    * {@inheritdoc}
    */
   public function preHandle(Request $request) {
+    // Sanitize the request.
+    $request = RequestSanitizer::sanitize(
+      $request,
+      (array) Settings::get(RequestSanitizer::SANITIZE_WHITELIST, []),
+      (bool) Settings::get(RequestSanitizer::SANITIZE_LOG, FALSE)
+    );
 
     $this->loadLegacyIncludes();
 

--- a/core/lib/Drupal/Core/Security/RequestSanitizer.php
+++ b/core/lib/Drupal/Core/Security/RequestSanitizer.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\Core\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Sanitizes user input.
+ */
+class RequestSanitizer {
+
+  /**
+   * Request attribute to mark the request as sanitized.
+   */
+  const SANITIZED = '_drupal_request_sanitized';
+
+  /**
+   * The name of the setting that configures the whitelist.
+   */
+  const SANITIZE_WHITELIST = 'sanitize_input_whitelist';
+
+  /**
+   * The name of the setting that determines if sanitized keys are logged.
+   */
+  const SANITIZE_LOG = 'sanitize_input_logging';
+
+  /**
+   * Strips dangerous keys from user input.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The incoming request to sanitize.
+   * @param string[] $whitelist
+   *   An array of keys to whitelist as safe. See default.settings.php.
+   * @param bool $log_sanitized_keys
+   *   (optional) Set to TRUE to log an keys that are sanitized.
+   *
+   * @return \Symfony\Component\HttpFoundation\Request
+   *   The sanitized request.
+   */
+  public static function sanitize(Request $request, $whitelist, $log_sanitized_keys = FALSE) {
+    if (!$request->attributes->get(self::SANITIZED, FALSE)) {
+      // Process query string parameters.
+      $get_sanitized_keys = [];
+      $request->query->replace(static::stripDangerousValues($request->query->all(), $whitelist, $get_sanitized_keys));
+      if ($log_sanitized_keys && !empty($get_sanitized_keys)) {
+        trigger_error(sprintf('Potentially unsafe keys removed from query string parameters (GET): %s', implode(', ', $get_sanitized_keys)));
+      }
+
+      // Request body parameters.
+      $post_sanitized_keys = [];
+      $request->request->replace(static::stripDangerousValues($request->request->all(), $whitelist, $post_sanitized_keys));
+      if ($log_sanitized_keys && !empty($post_sanitized_keys)) {
+        trigger_error(sprintf('Potentially unsafe keys removed from request body parameters (POST): %s', implode(', ', $post_sanitized_keys)));
+      }
+
+      // Cookie parameters.
+      $cookie_sanitized_keys = [];
+      $request->cookies->replace(static::stripDangerousValues($request->cookies->all(), $whitelist, $cookie_sanitized_keys));
+      if ($log_sanitized_keys && !empty($cookie_sanitized_keys)) {
+        trigger_error(sprintf('Potentially unsafe keys removed from cookie parameters: %s', implode(', ', $cookie_sanitized_keys)));
+      }
+
+      if (!empty($get_sanitized_keys) || !empty($post_sanitized_keys) || !empty($cookie_sanitized_keys)) {
+        $request->overrideGlobals();
+      }
+      $request->attributes->set(self::SANITIZED, TRUE);
+    }
+    return $request;
+  }
+
+  /**
+   * Strips dangerous keys from $input.
+   *
+   * @param mixed $input
+   *   The input to sanitize.
+   * @param string[] $whitelist
+   *   An array of keys to whitelist as safe.
+   * @param string[] $sanitized_keys
+   *   An array of keys that have been removed.
+   *
+   * @return mixed
+   *   The sanitized input.
+   */
+  protected static function stripDangerousValues($input, array $whitelist, array &$sanitized_keys) {
+    if (is_array($input)) {
+      foreach ($input as $key => $value) {
+        if ($key !== '' && $key[0] === '#' && !in_array($key, $whitelist, TRUE)) {
+          unset($input[$key]);
+          $sanitized_keys[] = $key;
+        }
+        else {
+          $input[$key] = static::stripDangerousValues($input[$key], $whitelist, $sanitized_keys);
+        }
+      }
+    }
+    return $input;
+  }
+
+}

--- a/core/misc/drupal.js
+++ b/core/misc/drupal.js
@@ -240,9 +240,10 @@ window.Drupal = {behaviors: {}, locale: {}};
   Drupal.checkPlain = function (str) {
     str = str.toString()
       .replace(/&/g, '&amp;')
-      .replace(/"/g, '&quot;')
       .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
     return str;
   };
 

--- a/core/modules/comment/src/Controller/CommentController.php
+++ b/core/modules/comment/src/Controller/CommentController.php
@@ -279,9 +279,12 @@ class CommentController extends ControllerBase {
     // Check if the user has the proper permissions.
     $access = AccessResult::allowedIfHasPermission($account, 'post comments');
 
+    // If commenting is open on the entity.
     $status = $entity->{$field_name}->status;
     $access = $access->andIf(AccessResult::allowedIf($status == CommentItemInterface::OPEN)
-      ->addCacheableDependency($entity));
+      ->addCacheableDependency($entity))
+      // And if user has access to the host entity.
+      ->andIf(AccessResult::allowedIf($entity->access('view')));
 
     // $pid indicates that this is a reply to a comment.
     if ($pid) {

--- a/core/modules/comment/src/Tests/CommentNonNodeTest.php
+++ b/core/modules/comment/src/Tests/CommentNonNodeTest.php
@@ -448,6 +448,7 @@ class CommentNonNodeTest extends WebTestBase {
       'post comments',
       'administer comment fields',
       'administer comment types',
+      'view test entity',
     ]);
     $this->drupalLogin($limited_user);
 

--- a/core/modules/comment/src/Tests/CommentTokenReplaceTest.php
+++ b/core/modules/comment/src/Tests/CommentTokenReplaceTest.php
@@ -144,6 +144,7 @@ class CommentTokenReplaceTest extends CommentTestBase {
 
     // Create a user and a comment.
     $user = User::create(['name' => 'alice']);
+    $user->activate();
     $user->save();
     $this->postComment($user, 'user body', 'user subject', TRUE);
 

--- a/core/modules/comment/tests/src/Functional/CommentAccessTest.php
+++ b/core/modules/comment/tests/src/Functional/CommentAccessTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Drupal\Tests\comment\Functional;
+
+use Drupal\comment\Entity\Comment;
+use Drupal\comment\Tests\CommentTestTrait;
+use Drupal\node\Entity\NodeType;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests comment administration and preview access.
+ *
+ * @group comment
+ */
+class CommentAccessTest extends BrowserTestBase {
+
+  use CommentTestTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'node',
+    'comment',
+  ];
+
+  /**
+   * Node for commenting.
+   *
+   * @var \Drupal\node\NodeInterface
+   */
+  protected $unpublishedNode;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    $node_type = NodeType::create([
+      'type' => 'article',
+      'name' => 'Article',
+    ]);
+    $node_type->save();
+    $node_author = $this->drupalCreateUser([
+      'create article content',
+      'access comments',
+    ]);
+
+    $this->drupalLogin($this->drupalCreateUser([
+      'edit own comments',
+      'skip comment approval',
+      'post comments',
+      'access comments',
+      'access content',
+    ]));
+
+    $this->addDefaultCommentField('node', 'article');
+    $this->unpublishedNode = $this->createNode([
+      'title' => 'This is unpublished',
+      'uid' => $node_author->id(),
+      'status' => 0,
+      'type' => 'article',
+    ]);
+    $this->unpublishedNode->save();
+  }
+
+  /**
+   * Tests commenting disabled for access-blocked entities.
+   */
+  public function testCannotCommentOnEntitiesYouCannotView() {
+    $assert = $this->assertSession();
+
+    $comment_url = 'comment/reply/node/' . $this->unpublishedNode->id() . '/comment';
+
+    // Commenting on an unpublished node results in access denied.
+    $this->drupalGet($comment_url);
+    $assert->statusCodeEquals(403);
+
+    // Publishing the node grants access.
+    $this->unpublishedNode->setPublished(TRUE)->save();
+    $this->drupalGet($comment_url);
+    $assert->statusCodeEquals(200);
+  }
+
+  /**
+   * Tests cannot view comment reply form on entities you cannot view.
+   */
+  public function testCannotViewCommentReplyFormOnEntitiesYouCannotView() {
+    $assert = $this->assertSession();
+
+    // Create a comment on an unpublished node.
+    $comment = Comment::create([
+      'entity_type' => 'node',
+      'name' => 'Tony',
+      'hostname' => 'magic.example.com',
+      'mail' => 'foo@example.com',
+      'subject' => 'Comment on unpublished node',
+      'entity_id' => $this->unpublishedNode->id(),
+      'comment_type' => 'comment',
+      'field_name' => 'comment',
+      'pid' => 0,
+      'uid' => $this->unpublishedNode->getOwnerId(),
+      'status' => 1,
+    ]);
+    $comment->save();
+
+    $comment_url = 'comment/reply/node/' . $this->unpublishedNode->id() . '/comment/' . $comment->id();
+
+    // Replying to a comment on an unpublished node results in access denied.
+    $this->drupalGet($comment_url);
+    $assert->statusCodeEquals(403);
+
+    // Publishing the node grants access.
+    $this->unpublishedNode->setPublished(TRUE)->save();
+    $this->drupalGet($comment_url);
+    $assert->statusCodeEquals(200);
+  }
+
+}

--- a/core/modules/node/node.install
+++ b/core/modules/node/node.install
@@ -246,3 +246,15 @@ function node_update_8301() {
   $entity_type->set('entity_keys', $keys);
   $definition_update_manager->updateEntityType($entity_type);
 }
+
+/**
+ * Run a node access rebuild, if required.
+ */
+function node_update_8302() {
+  // Get the list of node access modules.
+  $modules = \Drupal::moduleHandler()->getImplementations('node_grants');
+  // If multilingual usage, then rebuild node access.
+  if (count($modules) > 0 && \Drupal::languageManager()->isMultilingual()) {
+    node_access_needs_rebuild(TRUE);
+  }
+}

--- a/core/modules/node/src/NodeGrantDatabaseStorage.php
+++ b/core/modules/node/src/NodeGrantDatabaseStorage.php
@@ -211,6 +211,7 @@ class NodeGrantDatabaseStorage implements NodeGrantDatabaseStorageInterface {
       $query = $this->database->insert('node_access')->fields(['nid', 'langcode', 'fallback', 'realm', 'gid', 'grant_view', 'grant_update', 'grant_delete']);
       // If we have defined a granted langcode, use it. But if not, add a grant
       // for every language this node is translated to.
+      $fallback_langcode = $node->getUntranslated()->language()->getId();
       foreach ($grants as $grant) {
         if ($realm && $realm != $grant['realm']) {
           continue;
@@ -227,7 +228,7 @@ class NodeGrantDatabaseStorage implements NodeGrantDatabaseStorageInterface {
             $grant['nid'] = $node->id();
             $grant['langcode'] = $grant_langcode;
             // The record with the original langcode is used as the fallback.
-            if ($grant['langcode'] == $node->language()->getId()) {
+            if ($grant['langcode'] == $fallback_langcode) {
               $grant['fallback'] = 1;
             }
             else {

--- a/core/modules/node/tests/src/Functional/NodeAccessLanguageFallbackTest.php
+++ b/core/modules/node/tests/src/Functional/NodeAccessLanguageFallbackTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace Drupal\Tests\node\Functional;
+
+use Drupal\language\Entity\ConfigurableLanguage;
+
+/**
+ * Tests that the node_access system stores the proper fallback marker.
+ *
+ * @group node
+ */
+class NodeAccessLanguageFallbackTest extends NodeTestBase {
+
+  /**
+   * Enable language and a non-language-aware node access module.
+   *
+   * @var array
+   */
+  public static $modules = ['language', 'node_access_test', 'content_translation'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // After enabling a node access module, the {node_access} table has to be
+    // rebuilt.
+    node_access_rebuild();
+
+    // Add Hungarian, Catalan, and Afrikaans.
+    ConfigurableLanguage::createFromLangcode('hu')->save();
+    ConfigurableLanguage::createFromLangcode('ca')->save();
+    ConfigurableLanguage::createFromLangcode('af')->save();
+
+    // Enable content translation for the current entity type.
+    \Drupal::service('content_translation.manager')->setEnabled('node', 'page', TRUE);
+  }
+
+  /**
+   * Tests node access fallback handling with multiple node languages.
+   */
+  public function testNodeAccessLanguageFallback() {
+    // The node_access_test module allows nodes to be marked private. We need to
+    // ensure that system honors the fallback system of node access properly.
+    // Note that node_access_test_language is language-sensitive and does not
+    // apply to the fallback test.
+
+    // Create one node in Hungarian and marked as private.
+    $node = $this->drupalCreateNode([
+      'body' => [[]],
+      'langcode' => 'hu',
+      'private' => [['value' => 1]],
+      'status' => 1,
+    ]);
+
+    // There should be one entry in node_access, with fallback set to hu.
+    $this->checkRecords(1, 'hu');
+
+    // Create a translation user.
+    $admin = $this->drupalCreateUser([
+      'bypass node access',
+      'administer nodes',
+      'translate any entity',
+      'administer content translation',
+    ]);
+    $this->drupalLogin($admin);
+    $this->drupalGet('node/' . $node->id() . '/translations');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Create a Catalan translation through the UI.
+    $url_options = ['language' => \Drupal::languageManager()->getLanguage('ca')];
+    $this->drupalGet('node/' . $node->id() . '/translations/add/hu/ca', $url_options);
+    $this->assertSession()->statusCodeEquals(200);
+    // Save the form.
+    $this->getSession()->getPage()->pressButton('Save and keep published (this translation)');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // Check the node access table.
+    $this->checkRecords(2, 'hu');
+
+    // Programmatically create a translation. This process lets us check that
+    // both forms and code behave in the same way.
+    $storage = \Drupal::entityTypeManager()->getStorage('node');
+    // Reload the node.
+    $node = $storage->load(1);
+    // Create an Afrikaans translation.
+    $translation = $node->addTranslation('af');
+    $translation->title->value = $this->randomString();
+    $translation->status = 1;
+    $node->save();
+
+    // Check the node access table.
+    $this->checkRecords(3, 'hu');
+
+    // For completeness, edit the Catalan version again.
+    $this->drupalGet('node/' . $node->id() . '/edit', $url_options);
+    $this->assertSession()->statusCodeEquals(200);
+    // Save the form.
+    $this->getSession()->getPage()->pressButton('Save and keep published (this translation)');
+    $this->assertSession()->statusCodeEquals(200);
+    // Check the node access table.
+    $this->checkRecords(3, 'hu');
+  }
+
+  /**
+   * Queries the node_access table and checks for proper storage.
+   *
+   * @param int $count
+   *   The number of rows expected by the query (equal to the translation
+   *   count).
+   * @param $langcode
+   *   The expected language code set as the fallback property.
+   */
+  public function checkRecords($count, $langcode = 'hu') {
+    $select = \Drupal::database()
+      ->select('node_access', 'na')
+      ->fields('na', ['nid', 'fallback', 'langcode', 'grant_view'])
+      ->condition('na.realm', 'node_access_test', '=')
+      ->condition('na.gid', 8888, '=');
+    $records = $select->execute()->fetchAll();
+    // Check that the expected record count is returned.
+    $this->assertEquals(count($records), $count);
+    // The fallback value is 'hu' and should be set to 1. For other languages,
+    // it should be set to 0. Casting to boolean lets us run that comparison.
+    foreach ($records as $record) {
+      $this->assertEquals((bool) $record->fallback, $record->langcode === $langcode);
+    }
+  }
+
+}

--- a/core/modules/outside_in/src/Form/SystemBrandingOffCanvasForm.php
+++ b/core/modules/outside_in/src/Form/SystemBrandingOffCanvasForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\PluginFormBase;
+use Drupal\Core\Session\AccountInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -30,13 +31,23 @@ class SystemBrandingOffCanvasForm extends PluginFormBase implements ContainerInj
   protected $configFactory;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
    * SystemBrandingOffCanvasForm constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The config factory.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
+  public function __construct(ConfigFactoryInterface $config_factory, AccountInterface $current_user) {
     $this->configFactory = $config_factory;
+    $this->currentUser = $current_user;
   }
 
   /**
@@ -44,7 +55,8 @@ class SystemBrandingOffCanvasForm extends PluginFormBase implements ContainerInj
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('current_user')
     );
   }
 
@@ -65,6 +77,7 @@ class SystemBrandingOffCanvasForm extends PluginFormBase implements ContainerInj
       '#type' => 'details',
       '#title' => t('Site details'),
       '#open' => TRUE,
+      '#access' => $this->currentUser->hasPermission('administer site configuration'),
     ];
     $form['site_information']['site_name'] = [
       '#type' => 'textfield',

--- a/core/modules/outside_in/src/Form/SystemMenuOffCanvasForm.php
+++ b/core/modules/outside_in/src/Form/SystemMenuOffCanvasForm.php
@@ -85,6 +85,7 @@ class SystemMenuOffCanvasForm extends PluginFormBase implements ContainerInjecti
       '#type' => 'details',
       '#title' => $this->t('Edit menu %label', ['%label' => $this->menu->label()]),
       '#open' => TRUE,
+      '#access' => $this->menu->access('edit'),
     ];
     $form['entity_form'] += $this->getEntityForm($this->menu)->buildForm([], $form_state);
 

--- a/core/modules/outside_in/tests/src/FunctionalJavascript/OutsideInBlockFormTest.php
+++ b/core/modules/outside_in/tests/src/FunctionalJavascript/OutsideInBlockFormTest.php
@@ -6,6 +6,7 @@ use Drupal\block\Entity\Block;
 use Drupal\block_content\Entity\BlockContent;
 use Drupal\block_content\Entity\BlockContentType;
 use Drupal\user\Entity\Role;
+use Drupal\user\RoleInterface;
 
 /**
  * Testing opening and saving block forms in the off-canvas dialog.
@@ -29,12 +30,13 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
     'toolbar',
     'contextual',
     'outside_in',
-    'quickedit',
     'search',
     'block_content',
     // Add test module to override CSS pointer-events properties because they
     // cause test failures.
     'outside_in_test_css',
+    'menu_link_content',
+    'menu_ui',
   ];
 
   /**
@@ -50,7 +52,6 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
       'access contextual links',
       'access toolbar',
       'administer nodes',
-      'access in-place editing',
       'search content',
     ]);
     $this->drupalLogin($user);
@@ -62,7 +63,10 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
    *
    * @dataProvider providerTestBlocks
    */
-  public function testBlocks($block_plugin, $new_page_text, $element_selector, $label_selector, $button_text, $toolbar_item) {
+  public function testBlocks($block_plugin, $new_page_text, $element_selector, $label_selector, $button_text, $toolbar_item, $permissions) {
+    if ($permissions) {
+      $this->grantPermissions(Role::load(Role::AUTHENTICATED_ID), $permissions);
+    }
     $web_assert = $this->assertSession();
     $page = $this->getSession()->getPage();
     foreach ($this->getTestThemes() as $theme) {
@@ -159,6 +163,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
         'label_selector' => 'h2',
         'button_text' => 'Save Powered by Drupal',
         'toolbar_item' => '#toolbar-item-user',
+        NULL,
       ],
       'block-branding' => [
         'block_plugin' => 'system_branding_block',
@@ -167,6 +172,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
         'label_selector' => "a[rel='home']:last-child",
         'button_text' => 'Save Site branding',
         'toolbar_item' => '#toolbar-item-administration',
+        ['administer site configuration'],
       ],
       'block-search' => [
         'block_plugin' => 'search_form_block',
@@ -175,6 +181,7 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
         'label_selector' => 'h2',
         'button_text' => 'Save Search form',
         'toolbar_item' => NULL,
+        NULL,
       ],
     ];
     return $blocks;
@@ -239,6 +246,8 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
    * Tests QuickEdit links behavior.
    */
   public function testQuickEditLinks() {
+    $this->container->get('module_installer')->install(['quickedit']);
+    $this->grantPermissions(Role::load(RoleInterface::AUTHENTICATED_ID), ['access in-place editing']);
     $quick_edit_selector = '#quickedit-entity-toolbar';
     $node_selector = '[data-quickedit-entity-id="node/1"]';
     $body_selector = '[data-quickedit-field-id="node/1/body/en/full"]';
@@ -461,6 +470,8 @@ class OutsideInBlockFormTest extends OutsideInJavascriptTestBase {
    * "Quick edit settings" is outside_in.module link.
    */
   public function testCustomBlockLinks() {
+    $this->container->get('module_installer')->install(['quickedit']);
+    $this->grantPermissions(Role::load(RoleInterface::AUTHENTICATED_ID), ['access in-place editing']);
     $this->drupalGet('user');
     $page = $this->getSession()->getPage();
     $links = $page->findAll('css', "#block-custom .contextual-links li a");

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -386,7 +386,52 @@ function update_get_available($refresh = FALSE) {
     $available = \Drupal::keyValueExpirable('update_available_releases')->getAll();
   }
 
+  // Check for security releases that are covered under the same security
+  // advisories as the site's current release, and override the update status
+  // data so that those releases are not flagged as needed security updates.
+  // Any security releases beyond those specific releases will still be shown
+  // as required security updates.
+
+  // @todo This is a temporary fix to allow minor-version backports of security
+  //   fixes to be shown as secure. It should not be included in the codebase of
+  //   any release or branch other than such backports. Replace this with
+  //   https://www.drupal.org/project/drupal/issues/2766491.
+  foreach (_update_equivalent_security_releases() as $equivalent_release) {
+    if (!empty($available['drupal']['releases'][$equivalent_release]['terms']['Release type'])) {
+      $security_release_key = array_search('Security update', $available['drupal']['releases'][$equivalent_release]['terms']['Release type']);
+      if ($security_release_key !== FALSE) {
+        unset($available['drupal']['releases'][$equivalent_release]['terms']['Release type'][$security_release_key]);
+      }
+    }
+  }
   return $available;
+}
+
+/**
+ * Identifies equivalent security releases with a hardcoded list.
+ *
+ * Generally, only the latest minor version of Drupal 8 is supported. However,
+ * when security fixes are backported to an old branch, and the site owner
+ * updates to the release containing the backported fix, they should not
+ * see "Security update required!" again if the only other security releases
+ * are releases for the same advisories.
+ *
+ * @return string[]
+ *   A list of security release numbers that are equivalent to this release
+ *   (i.e. covered by the same advisory), for backported security fixes only.
+ *
+ * @todo This is a temporary fix to allow minor-version backports of security
+ *   fixes to be shown as secure. It should not be included in the codebase of
+ *   any release or branch other than such backports. Replace this with
+ *   https://www.drupal.org/project/drupal/issues/2766491.
+ */
+function _update_equivalent_security_releases() {
+  switch (\Drupal::VERSION) {
+    case '8.3.8':
+      return ['8.4.5', '8.5.0-rc1'];
+  }
+
+  return [];
 }
 
 /**

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -429,6 +429,8 @@ function _update_equivalent_security_releases() {
   switch (\Drupal::VERSION) {
     case '8.3.8':
       return ['8.4.5', '8.5.0-rc1'];
+    case '8.3.9':
+      return ['8.4.6', '8.5.1'];
   }
 
   return [];

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -1562,6 +1562,7 @@ return array(
     'Drupal\\Core\\Routing\\UrlGeneratorInterface' => $baseDir . '/core/lib/Drupal/Core/Routing/UrlGeneratorInterface.php',
     'Drupal\\Core\\Routing\\UrlGeneratorTrait' => $baseDir . '/core/lib/Drupal/Core/Routing/UrlGeneratorTrait.php',
     'Drupal\\Core\\Routing\\UrlMatcher' => $baseDir . '/core/lib/Drupal/Core/Routing/UrlMatcher.php',
+    'Drupal\\Core\\Security\\RequestSanitizer' => $baseDir . '/core/lib/Drupal/Core/Security/RequestSanitizer.php',
     'Drupal\\Core\\Serialization\\Yaml' => $baseDir . '/core/lib/Drupal/Core/Serialization/Yaml.php',
     'Drupal\\Core\\Session\\AccountInterface' => $baseDir . '/core/lib/Drupal/Core/Session/AccountInterface.php',
     'Drupal\\Core\\Session\\AccountProxy' => $baseDir . '/core/lib/Drupal/Core/Session/AccountProxy.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -1850,6 +1850,7 @@ class ComposerStaticInitDrupal8
         'Drupal\\Core\\Routing\\UrlGeneratorInterface' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Routing/UrlGeneratorInterface.php',
         'Drupal\\Core\\Routing\\UrlGeneratorTrait' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Routing/UrlGeneratorTrait.php',
         'Drupal\\Core\\Routing\\UrlMatcher' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Routing/UrlMatcher.php',
+        'Drupal\\Core\\Security\\RequestSanitizer' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Security/RequestSanitizer.php',
         'Drupal\\Core\\Serialization\\Yaml' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Serialization/Yaml.php',
         'Drupal\\Core\\Session\\AccountInterface' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Session/AccountInterface.php',
         'Drupal\\Core\\Session\\AccountProxy' => __DIR__ . '/../..' . '/core/lib/Drupal/Core/Session/AccountProxy.php',


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.3.9
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.