### PR TITLE
Remove overly aggressive 'Icon' from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ sites/simpletest
 ######################
 .DS_Store*
 ehthumbs.db
-Icon
 
 Thumbs.db
 ._*


### PR DESCRIPTION
The "Icon" line in .gitignore is causing problems with the Drupal core directory "core/lib/Drupal/Core/Layout/Icon/"

I don't have any "Icon" files on my OS, so i'm not sure if total removal is the best method to address, or if there's a better compromise.