### PR TITLE
Update drops-8 to 8.6.1

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.6.0';
+  const VERSION = '8.6.1';
 
   /**
    * Core API compatibility.

--- a/core/modules/editor/src/Form/EditorImageDialog.php
+++ b/core/modules/editor/src/Form/EditorImageDialog.php
@@ -141,7 +141,7 @@ class EditorImageDialog extends FormBase {
     }
     $form['attributes']['alt'] = [
       '#title' => $this->t('Alternative text'),
-      '#placeholder' => $this->t('Short description for the visually impaired'),
+      '#description' => $this->t('Short description of the image used by screen readers and displayed when the image is not loaded. This is important for accessibility.'),
       '#type' => 'textfield',
       '#required' => TRUE,
       '#required_error' => $this->t('Alternative text is required.<br />(Only in rare cases should this be left empty. To create empty alternative text, enter <code>""</code> — two double quotes without any content).'),

--- a/core/modules/image/src/Plugin/Field/FieldType/ImageItem.php
+++ b/core/modules/image/src/Plugin/Field/FieldType/ImageItem.php
@@ -263,7 +263,7 @@ class ImageItem extends FileItem {
       '#type' => 'checkbox',
       '#title' => t('Enable <em>Alt</em> field'),
       '#default_value' => $settings['alt_field'],
-      '#description' => t('The alt attribute may be used by search engines, screen readers, and when the image cannot be loaded. Enabling this field is recommended.'),
+      '#description' => t('Short description of the image used by screen readers and displayed when the image is not loaded. Enabling this field is recommended.'),
       '#weight' => 9,
     ];
     $element['alt_field_required'] = [
@@ -433,7 +433,7 @@ class ImageItem extends FileItem {
     $element['default_image']['alt'] = [
       '#type' => 'textfield',
       '#title' => t('Alternative text'),
-      '#description' => t('This text will be used by screen readers, search engines, and when the image cannot be loaded.'),
+      '#description' => t('Short description of the image used by screen readers and displayed when the image is not loaded. This is important for accessibility.'),
       '#default_value' => $settings['default_image']['alt'],
       '#maxlength' => 512,
     ];

--- a/core/modules/image/src/Plugin/Field/FieldWidget/ImageWidget.php
+++ b/core/modules/image/src/Plugin/Field/FieldWidget/ImageWidget.php
@@ -263,7 +263,7 @@ class ImageWidget extends FileWidget {
       '#title' => t('Alternative text'),
       '#type' => 'textfield',
       '#default_value' => isset($item['alt']) ? $item['alt'] : '',
-      '#description' => t('This text will be used by screen readers, search engines, or when the image cannot be loaded.'),
+      '#description' => t('Short description of the image used by screen readers and displayed when the image is not loaded. This is important for accessibility.'),
       // @see https://www.drupal.org/node/465106#alt-text
       '#maxlength' => 512,
       '#weight' => -12,

--- a/core/modules/taxonomy/taxonomy.install
+++ b/core/modules/taxonomy/taxonomy.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\Site\Settings;
 
 /**
  * Convert the custom taxonomy term hierarchy storage to a default storage.
@@ -28,6 +29,9 @@ function taxonomy_update_8502(&$sandbox) {
   if (!isset($sandbox['current'])) {
     // Set batch ops sandbox.
     $sandbox['current'] = 0;
+    $sandbox['tid'] = -1;
+    $sandbox['delta'] = 0;
+    $sandbox['limit'] = Settings::get('entity_update_batch_size', 50);
     $sandbox['max'] = $database->select('taxonomy_term_hierarchy')
       ->countQuery()
       ->execute()
@@ -40,19 +44,20 @@ function taxonomy_update_8502(&$sandbox) {
   $hierarchy = $select
     ->fields('h', ['tid', 'parent'])
     ->fields('d', ['vid', 'langcode'])
-    ->range($sandbox['current'], $sandbox['current'] + 100)
+    ->range($sandbox['current'], $sandbox['limit'])
+    ->orderBy('tid', 'ASC')
+    ->orderBy('parent', 'ASC')
     ->execute()
     ->fetchAll();
 
   // Restore data.
   $insert = $database->insert('taxonomy_term__parent')
     ->fields(['bundle', 'entity_id', 'revision_id', 'langcode', 'delta', 'parent_target_id']);
-  $tid = -1;
 
   foreach ($hierarchy as $row) {
-    if ($row->tid !== $tid) {
-      $delta = 0;
-      $tid = $row->tid;
+    if ($row->tid !== $sandbox['tid']) {
+      $sandbox['delta'] = 0;
+      $sandbox['tid'] = $row->tid;
     }
 
     $insert->values([
@@ -60,11 +65,11 @@ function taxonomy_update_8502(&$sandbox) {
       'entity_id' => $row->tid,
       'revision_id' => $row->tid,
       'langcode' => $row->langcode,
-      'delta' => $delta,
+      'delta' => $sandbox['delta'],
       'parent_target_id' => $row->parent,
     ]);
 
-    $delta++;
+    $sandbox['delta']++;
     $sandbox['current']++;
   }
 

--- a/core/modules/taxonomy/tests/src/Functional/Update/TaxonomyParentUpdateTest.php
+++ b/core/modules/taxonomy/tests/src/Functional/Update/TaxonomyParentUpdateTest.php
@@ -47,6 +47,16 @@ class TaxonomyParentUpdateTest extends UpdatePathTestBase {
    * @see taxonomy_update_8503()
    */
   public function testTaxonomyUpdateParents() {
+    // Force the update hook to only run one term per batch.
+    drupal_rewrite_settings([
+      'settings' => [
+        'entity_update_batch_size' => (object) [
+          'value' => 1,
+          'required' => TRUE,
+        ],
+      ],
+    ]);
+
     // Run updates.
     $this->runUpdates();
 


### PR DESCRIPTION
Inspect the result of the [functional tests run by Circle CI](https://circleci.com/gh/pantheon-systems/drops-8). These tests will create a [multidev environment in the ci-drops-8 test site](https://admin.dashboard.pantheon.io/sites/689219ca-6583-4af8-ab05-2cebf6ef79a0#multidev/dev-environments) that may be browsed after the tests complete.

**OPTIONAL** -- To create your own test site:

- Create a new Drupal 8 site on Pantheon.
- When site creation is finished, visit dashboard.
- Switch to "git" mode.
- Clone your site locally.
- Apply the files from this PR on top of your local checkout.
  - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
  - git fetch drops-8
  - git merge drops-8/update-8.6.1
- Push your files back up to Pantheon.
- Switch back to sftp mode.
- Visit your site and step through the installation process.