### PR TITLE
Update to Drupal 8.6.12. For more information, see https://www.drupal.org/project/drupal/releases/8.6.12

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.6.11';
+  const VERSION = '8.6.12';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Template/TwigEnvironment.php
+++ b/core/lib/Drupal/Core/Template/TwigEnvironment.php
@@ -137,7 +137,7 @@ class TwigEnvironment extends \Twig_Environment {
     // node.html.twig for the output of each node and the same compiled class.
     $cache_index = $name . (NULL === $index ? '' : '_' . $index);
     if (!isset($this->templateClasses[$cache_index])) {
-      $this->templateClasses[$cache_index] = $this->templateClassPrefix . hash('sha256', $this->loader->getCacheKey($name)) . (NULL === $index ? '' : '_' . $index);
+      $this->templateClasses[$cache_index] = parent::getTemplateClass($name, $index);
     }
     return $this->templateClasses[$cache_index];
   }

--- a/core/modules/system/tests/modules/twig_theme_test/src/TwigThemeTestController.php
+++ b/core/modules/system/tests/modules/twig_theme_test/src/TwigThemeTestController.php
@@ -104,4 +104,11 @@ class TwigThemeTestController {
     ];
   }
 
+  /**
+   * Renders for testing the embed tag in a Twig template.
+   */
+  public function embedTagRender() {
+    return ['#theme' => 'twig_theme_test_embed_tag'];
+  }
+
 }

--- a/core/modules/system/tests/modules/twig_theme_test/templates/twig-theme-test-embed-tag-embedded.html.twig
+++ b/core/modules/system/tests/modules/twig_theme_test/templates/twig-theme-test-embed-tag-embedded.html.twig
@@ -1,0 +1,1 @@
+This line is from twig_theme_test/templates/twig-theme-test-embed-tag-embedded.html.twig

--- a/core/modules/system/tests/modules/twig_theme_test/templates/twig_theme_test.embed_tag.html.twig
+++ b/core/modules/system/tests/modules/twig_theme_test/templates/twig_theme_test.embed_tag.html.twig
@@ -1,0 +1,3 @@
+{% embed "@twig_theme_test/twig-theme-test-embed-tag-embedded.html.twig" %}
+
+{% endembed %}

--- a/core/modules/system/tests/modules/twig_theme_test/twig_theme_test.module
+++ b/core/modules/system/tests/modules/twig_theme_test/twig_theme_test.module
@@ -73,6 +73,10 @@ function twig_theme_test_theme($existing, $type, $theme, $path) {
     ],
     'template' => 'twig_theme_test.renderable',
   ];
+  $items['twig_theme_test_embed_tag'] = [
+    'variables' => [],
+    'template' => 'twig_theme_test.embed_tag',
+  ];
   return $items;
 }
 

--- a/core/modules/system/tests/modules/twig_theme_test/twig_theme_test.routing.yml
+++ b/core/modules/system/tests/modules/twig_theme_test/twig_theme_test.routing.yml
@@ -69,3 +69,10 @@ twig_theme_test_renderable:
     _controller: '\Drupal\twig_theme_test\TwigThemeTestController::renderable'
   requirements:
     _access: 'TRUE'
+
+twig_theme_test_embed_tag:
+  path: '/twig-theme-test/embed-tag'
+  defaults:
+    _controller: '\Drupal\twig_theme_test\TwigThemeTestController::embedTagRender'
+  requirements:
+    _access: 'TRUE'

--- a/core/modules/system/tests/src/Functional/Theme/TwigEnvironmentTest.php
+++ b/core/modules/system/tests/src/Functional/Theme/TwigEnvironmentTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\Tests\system\Functional\Theme;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests Twig environment.
+ *
+ * @group Theme
+ */
+class TwigEnvironmentTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['twig_theme_test'];
+
+  /**
+   * Tests template class loading with Twig embed.
+   */
+  public function testTwigEmbed() {
+    $assert_session = $this->assertSession();
+    // Test the Twig embed tag.
+    $this->drupalGet('twig-theme-test/embed-tag');
+    $assert_session->statusCodeEquals(200);
+    $assert_session->responseContains('This line is from twig_theme_test/templates/twig-theme-test-embed-tag-embedded.html.twig');
+  }
+
+}


### PR DESCRIPTION
Update from Drupal 8.6.11 to Drupal 8.6.12.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-8), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 8 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
    - git fetch drops-8
    - git merge drops-8/update-8.6.12
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
