### PR TITLE
CORE-1128: Update to PHP 7.3. 

### DIFF
--- a/.circleci/features/phpversion.feature
+++ b/.circleci/features/phpversion.feature
@@ -7,4 +7,4 @@ Feature: Check php version
   Scenario: Check the php version in the phpinfo output
     Given I am logged in as a user with the "administrator" role
     And I am on "/admin/reports/status/php"
-    Then I should see "PHP Version 7.2"
+    Then I should see "PHP Version 7.3"

--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,4 +3,4 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 7.2
+php_version: 7.3


### PR DESCRIPTION
For details see https://pantheon.io/blog/faster-wordpress-drupal-8-sites-php-73-default.

The PHP 7.2 update was 9ec121045

Going to let the first build fail to confirm that we are testing for the PHP patch version. After the failure is confirmed, I'll update the tests for 7.3 as well.