### PR TITLE
Update to Drupal 8.7.5. For more information, see https://www.drupal.org/project/drupal/releases/8.7.5

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.7.4';
+  const VERSION = '8.7.5';
 
   /**
    * Core API compatibility.

--- a/core/modules/workspaces/src/EntityAccess.php
+++ b/core/modules/workspaces/src/EntityAccess.php
@@ -124,10 +124,8 @@ class EntityAccess implements ContainerInjectionInterface {
     // to ALL THE THINGS! That's why this is a dangerous permission.
     $active_workspace = $this->workspaceManager->getActiveWorkspace();
 
-    $owner_has_access = AccessResult::allowedIf($active_workspace->getOwnerId() == $account->id())
-      ->cachePerUser()->addCacheableDependency($active_workspace);
-    $access_bypass = AccessResult::allowedIfHasPermission($account, 'bypass entity access own workspace');
-    return $owner_has_access->orIf($access_bypass);
+    return AccessResult::allowedIf($active_workspace->getOwnerId() == $account->id())->cachePerUser()->addCacheableDependency($active_workspace)
+      ->andIf(AccessResult::allowedIfHasPermission($account, 'bypass entity access own workspace'));
   }
 
 }

--- a/core/modules/workspaces/tests/src/Functional/WorkspaceBypassTest.php
+++ b/core/modules/workspaces/tests/src/Functional/WorkspaceBypassTest.php
@@ -55,10 +55,10 @@ class WorkspaceBypassTest extends BrowserTestBase {
     $this->drupalLogin($lombardi);
     $this->switchToWorkspace($bears);
 
-    // Editor 2 should be able to create and edit any node because of the
-    // assigned bypass permission.
+    // Editor 2 has the bypass permission but does not own the workspace and so,
+    // should not be able to create and edit any node.
     $this->drupalGet('/node/' . $ditka_bears_node_id . '/edit');
-    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->statusCodeEquals(403);
   }
 
 }

--- a/core/modules/workspaces/workspaces.post_update.php
+++ b/core/modules/workspaces/workspaces.post_update.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * @file
+ * Post update functions for the Workspaces module.
+ */
+
+/**
+ * Clear caches due to access changes.
+ */
+function workspaces_post_update_access_clear_caches() {
+}


### PR DESCRIPTION
Update from Drupal 8.7.4 to Drupal 8.7.5.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-8), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 8 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
    - git fetch drops-8
    - git merge drops-8/update-8.7.5
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
