### PR TITLE
Update to Drupal 8.7.7. For more information, see https://www.drupal.org/project/drupal/releases/8.7.7

### DIFF
--- a/core/composer.json
+++ b/core/composer.json
@@ -50,7 +50,8 @@
         "pear/archive_tar": "^1.4"
     },
     "conflict": {
-        "drush/drush": "<8.1.10"
+        "drush/drush": "<8.1.10",
+        "symfony/dom-crawler": ">=4"
     },
     "require-dev": {
         "behat/mink": "1.7.x-dev",

--- a/core/includes/update.inc
+++ b/core/includes/update.inc
@@ -58,8 +58,7 @@ function update_check_incompatibility($name, $type = 'module') {
     $file = $themes[$name];
   }
   if (!isset($file)
-      || !isset($file->info['core'])
-      || $file->info['core'] != \Drupal::CORE_COMPATIBILITY
+      || $file->info['core_incompatible']
       || version_compare(phpversion(), $file->info['php']) < 0) {
     return TRUE;
   }

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.7.6';
+  const VERSION = '8.7.7';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Datetime/Element/Datetime.php
+++ b/core/lib/Drupal/Core/Datetime/Element/Datetime.php
@@ -397,7 +397,7 @@ class Datetime extends DateElementBase {
    * The format is important because these elements will not work with any other
    * format.
    *
-   * @param string $element
+   * @param array $element
    *   The $element to assess.
    *
    * @return string
@@ -424,7 +424,7 @@ class Datetime extends DateElementBase {
    * The format is important because these elements will not work with any other
    * format.
    *
-   * @param string $element
+   * @param array $element
    *   The $element to assess.
    *
    * @return string

--- a/core/lib/Drupal/Core/Entity/Plugin/DataType/Deriver/EntityDeriver.php
+++ b/core/lib/Drupal/Core/Entity/Plugin/DataType/Deriver/EntityDeriver.php
@@ -98,11 +98,12 @@ class EntityDeriver implements ContainerDeriverInterface {
       ] + $base_plugin_definition;
 
       // Incorporate the bundles as entity:$entity_type:$bundle, if any.
-      foreach ($this->bundleInfoService->getBundleInfo($entity_type_id) as $bundle => $bundle_info) {
-        if ($bundle !== $entity_type_id) {
+      $bundle_info = $this->bundleInfoService->getBundleInfo($entity_type_id);
+      if (count($bundle_info) > 1 || $entity_type->getKey('bundle')) {
+        foreach ($bundle_info as $bundle => $info) {
           $this->derivatives[$entity_type_id . ':' . $bundle] = [
             'class' => $class,
-            'label' => $bundle_info['label'],
+            'label' => $info['label'],
             'constraints' => $this->derivatives[$entity_type_id]['constraints'],
           ] + $base_plugin_definition;
         }

--- a/core/lib/Drupal/Core/Extension/InfoParserDynamic.php
+++ b/core/lib/Drupal/Core/Extension/InfoParserDynamic.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Core\Extension;
 
+use Composer\Semver\Semver;
 use Drupal\Component\Serialization\Exception\InvalidDataTypeException;
 use Drupal\Core\Serialization\Yaml;
 
@@ -9,6 +10,11 @@ use Drupal\Core\Serialization\Yaml;
  * Parses dynamic .info.yml files that might change during the page request.
  */
 class InfoParserDynamic implements InfoParserInterface {
+
+  /**
+   * The earliest Drupal version that supports the 'core_version_requirement'.
+   */
+  const FIRST_CORE_VERSION_REQUIREMENT_SUPPORTED_VERSION = '8.7.7';
 
   /**
    * {@inheritdoc}
@@ -28,6 +34,40 @@ class InfoParserDynamic implements InfoParserInterface {
       if (!empty($missing_keys)) {
         throw new InfoParserException('Missing required keys (' . implode(', ', $missing_keys) . ') in ' . $filename);
       }
+      if ($parsed_info['type'] === 'profile' && isset($parsed_info['core_version_requirement'])) {
+        // @todo Support the 'core_version_requirement' key in profiles in
+        //   https://www.drupal.org/node/3070401.
+        throw new InfoParserException("The 'core_version_requirement' key is not supported in profiles in $filename");
+      }
+      if (!isset($parsed_info['core']) && !isset($parsed_info['core_version_requirement'])) {
+        throw new InfoParserException("The 'core' or the 'core_version_requirement' key must be present in " . $filename);
+      }
+      if (isset($parsed_info['core']) && !preg_match("/^\d\.x$/", $parsed_info['core'])) {
+        throw new InfoParserException("Invalid 'core' value \"{$parsed_info['core']}\" in " . $filename);
+      }
+      if (isset($parsed_info['core_version_requirement'])) {
+        $supports_pre_core_version_requirement_version = static::isConstraintSatisfiedByPreviousVersion($parsed_info['core_version_requirement'], static::FIRST_CORE_VERSION_REQUIREMENT_SUPPORTED_VERSION);
+        // If the 'core_version_requirement' constraint does not satisfy any
+        // Drupal 8 versions before 8.7.7 then 'core' cannot be set or it will
+        // effectively support all versions of Drupal 8 because
+        // 'core_version_requirement' will be ignored in previous versions.
+        if (!$supports_pre_core_version_requirement_version && isset($parsed_info['core'])) {
+          throw new InfoParserException("The 'core_version_requirement' constraint ({$parsed_info['core_version_requirement']}) requires the 'core' key not be set in " . $filename);
+        }
+        // 'core_version_requirement' can not be used to specify Drupal 8
+        // versions before 8.7.7 because these versions do not use the
+        // 'core_version_requirement' key. Do not throw the exception if the
+        // constraint also is satisfied by 8.0.0-alpha1 to allow constraints
+        // such as '^8' or '^8 || ^9'.
+        if ($supports_pre_core_version_requirement_version && !Semver::satisfies('8.0.0-alpha1', $parsed_info['core_version_requirement'])) {
+          throw new InfoParserException("The 'core_version_requirement' can not be used to specify compatibility for a specific version before " . static::FIRST_CORE_VERSION_REQUIREMENT_SUPPORTED_VERSION . " in $filename");
+        }
+      }
+
+      // Determine if the extension is compatible with the current version of
+      // Drupal core.
+      $core_version_constraint = isset($parsed_info['core_version_requirement']) ? $parsed_info['core_version_requirement'] : $parsed_info['core'];
+      $parsed_info['core_incompatible'] = !Semver::satisfies(\Drupal::VERSION, $core_version_constraint);
       if (isset($parsed_info['version']) && $parsed_info['version'] === 'VERSION') {
         $parsed_info['version'] = \Drupal::VERSION;
       }
@@ -60,7 +100,80 @@ class InfoParserDynamic implements InfoParserInterface {
    *   An array of required keys.
    */
   protected function getRequiredKeys() {
-    return ['type', 'core', 'name'];
+    return ['type', 'name'];
+  }
+
+  /**
+   * Determines if a constraint is satisfied by earlier versions of Drupal 8.
+   *
+   * @param string $constraint
+   *   A core semantic version constraint.
+   * @param string $version
+   *   A core version.
+   *
+   * @return bool
+   *   TRUE if the constraint is satisfied by a core version prior to the
+   *   provided version.
+   */
+  protected static function isConstraintSatisfiedByPreviousVersion($constraint, $version) {
+    static $evaluated_constraints = [];
+    // Any particular constraint and version combination only needs to be
+    // evaluated once.
+    if (!isset($evaluated_constraints[$constraint][$version])) {
+      $evaluated_constraints[$constraint][$version] = FALSE;
+      foreach (static::getAllPreviousCoreVersions($version) as $previous_version) {
+        if (Semver::satisfies($previous_version, $constraint)) {
+          $evaluated_constraints[$constraint][$version] = TRUE;
+          // The constraint only has to satisfy one previous version so break
+          // when the first one is found.
+          break;
+        }
+      }
+    }
+    return $evaluated_constraints[$constraint][$version];
+  }
+
+  /**
+   * Gets all the versions of Drupal 8 before a specific version.
+   *
+   * @param string $version
+   *   The version to get versions before.
+   *
+   * @return array
+   *   All of the applicable Drupal 8 releases.
+   */
+  protected static function getAllPreviousCoreVersions($version) {
+    static $versions_lists = [];
+    // Check if list of previous versions for the specified version has already
+    // been created.
+    if (empty($versions_lists[$version])) {
+      // Loop through all minor versions including 8.7.
+      foreach (range(0, 7) as $minor) {
+        // The largest patch number in a release was 17 in 8.6.17. Use 27 to
+        // leave room for future security releases.
+        foreach (range(0, 27) as $patch) {
+          $patch_version = "8.$minor.$patch";
+          if ($patch_version === $version) {
+            // Reverse the order of the versions so that they will be evaluated
+            // from the most recent versions first.
+            $versions_lists[$version] = array_reverse($versions_lists[$version]);
+            return $versions_lists[$version];
+          }
+          if ($patch === 0) {
+            // If this is a '0' patch release like '8.1.0' first create the
+            // pre-release versions such as '8.1.0-alpha1' and '8.1.0-rc1'.
+            foreach (['alpha', 'beta', 'rc'] as $prerelease) {
+              // The largest prerelease number was  in 8.0.0-beta16.
+              foreach (range(0, 16) as $prerelease_number) {
+                $versions_lists[$version][] = "$patch_version-$prerelease$prerelease_number";
+              }
+            }
+          }
+          $versions_lists[$version][] = $patch_version;
+        }
+      }
+    }
+    return $versions_lists[$version];
   }
 
 }

--- a/core/lib/Drupal/Core/Extension/ModuleInstaller.php
+++ b/core/lib/Drupal/Core/Extension/ModuleInstaller.php
@@ -81,9 +81,14 @@ class ModuleInstaller implements ModuleInstallerInterface {
    */
   public function install(array $module_list, $enable_dependencies = TRUE) {
     $extension_config = \Drupal::configFactory()->getEditable('core.extension');
+    // Get all module data so we can find dependencies and sort.
+    $module_data = system_rebuild_module_data();
+    foreach ($module_list as $module) {
+      if (!empty($module_data[$module]->info['core_incompatible'])) {
+        throw new MissingDependencyException("Unable to install modules: module '$module' is incompatible with this version of Drupal core.");
+      }
+    }
     if ($enable_dependencies) {
-      // Get all module data so we can find dependencies and sort.
-      $module_data = system_rebuild_module_data();
       $module_list = $module_list ? array_combine($module_list, $module_list) : [];
       if ($missing_modules = array_diff_key($module_list, $module_data)) {
         // One or more of the given modules doesn't exist.
@@ -108,6 +113,9 @@ class ModuleInstaller implements ModuleInstallerInterface {
 
           // Skip already installed modules.
           if (!isset($module_list[$dependency]) && !isset($installed_modules[$dependency])) {
+            if ($module_data[$dependency]->info['core_incompatible']) {
+              throw new MissingDependencyException("Unable to install modules: module '$module'. Its dependency module '$dependency' is incompatible with this version of Drupal core.");
+            }
             $module_list[$dependency] = $dependency;
           }
         }

--- a/core/lib/Drupal/Core/Template/TwigExtension.php
+++ b/core/lib/Drupal/Core/Template/TwigExtension.php
@@ -249,8 +249,8 @@ class TwigExtension extends \Twig_Extension {
    *   (optional) An associative array of additional options. The 'absolute'
    *   option is forced to be TRUE.
    *
-   * @return string
-   *   The generated absolute URL for the given route.
+   * @return array
+   *   A render array with generated absolute URL for the given route.
    *
    * @todo Add an option for scheme-relative URLs.
    */

--- a/core/modules/ckeditor/tests/src/FunctionalJavascript/CKEditorIntegrationTest.php
+++ b/core/modules/ckeditor/tests/src/FunctionalJavascript/CKEditorIntegrationTest.php
@@ -9,6 +9,7 @@ use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\filter\Entity\FilterFormat;
 use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
 use Drupal\node\Entity\NodeType;
+use Drupal\Tests\ckeditor\Traits\CKEditorTestTrait;
 
 /**
  * Tests the integration of CKEditor.
@@ -16,6 +17,8 @@ use Drupal\node\Entity\NodeType;
  * @group ckeditor
  */
 class CKEditorIntegrationTest extends WebDriverTestBase {
+
+  use CKEditorTestTrait;
 
   /**
    * The account.
@@ -160,7 +163,8 @@ class CKEditorIntegrationTest extends WebDriverTestBase {
 
     // If the caption filter is disabled, its checkbox should be absent.
     $this->drupalGet('node/add/page');
-    $this->click('.cke_button__drupalimage');
+    $this->waitForEditor();
+    $this->pressEditorButton('drupalimage');
     $this->assertNotEmpty($web_assert->waitForElement('css', '.ui-dialog'));
     $web_assert->elementNotExists('css', '.ui-dialog input[name="attributes[hasCaption]"]');
 
@@ -170,9 +174,10 @@ class CKEditorIntegrationTest extends WebDriverTestBase {
     ]);
     $this->filterFormat->save();
 
-    // If the caption filter is enabled,  its checkbox should be present.
+    // If the caption filter is enabled, its checkbox should be present.
     $this->drupalGet('node/add/page');
-    $this->click('.cke_button__drupalimage');
+    $this->waitForEditor();
+    $this->pressEditorButton('drupalimage');
     $this->assertNotEmpty($web_assert->waitForElement('css', '.ui-dialog'));
     $web_assert->elementExists('css', '.ui-dialog input[name="attributes[hasCaption]"]');
   }

--- a/core/modules/ckeditor/tests/src/Traits/CKEditorTestTrait.php
+++ b/core/modules/ckeditor/tests/src/Traits/CKEditorTestTrait.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\Tests\ckeditor\Traits;
+
+/**
+ * Provides methods to test CKEditor.
+ *
+ * This trait is meant to be used only by functional JavaScript test classes.
+ */
+trait CKEditorTestTrait {
+
+  /**
+   * Waits for CKEditor to initialize.
+   *
+   * @param string $instance_id
+   *   The CKEditor instance ID.
+   * @param int $timeout
+   *   (optional) Timeout in milliseconds, defaults to 10000.
+   */
+  protected function waitForEditor($instance_id = 'edit-body-0-value', $timeout = 10000) {
+    $condition = <<<JS
+      (function() {
+        return (
+          typeof CKEDITOR !== 'undefined'
+          && typeof CKEDITOR.instances["$instance_id"] !== 'undefined'
+          && CKEDITOR.instances["$instance_id"].instanceReady
+        );
+      }());
+JS;
+
+    $this->getSession()->wait($timeout, $condition);
+  }
+
+  /**
+   * Assigns a name to the CKEditor iframe.
+   *
+   * @see \Behat\Mink\Session::switchToIFrame()
+   */
+  protected function assignNameToCkeditorIframe() {
+    $javascript = <<<JS
+(function(){
+  document.getElementsByClassName('cke_wysiwyg_frame')[0].id = 'ckeditor';
+})()
+JS;
+    $this->getSession()->evaluateScript($javascript);
+  }
+
+  /**
+   * Clicks a CKEditor button.
+   *
+   * @param string $name
+   *   The name of the button, such as `drupallink`, `source`, etc.
+   */
+  protected function pressEditorButton($name) {
+    $this->getEditorButton($name)->click();
+  }
+
+  /**
+   * Waits for a CKEditor button and returns it when available and visible.
+   *
+   * @param string $name
+   *   The name of the button, such as `drupallink`, `source`, etc.
+   *
+   * @return \Behat\Mink\Element\NodeElement|null
+   *   The page element node if found, NULL if not.
+   */
+  protected function getEditorButton($name) {
+    $this->getSession()->switchToIFrame();
+    $button = $this->assertSession()->waitForElementVisible('css', 'a.cke_button__' . $name);
+    $this->assertNotEmpty($button);
+
+    return $button;
+  }
+
+  /**
+   * Asserts a CKEditor button is disabled.
+   *
+   * @param string $name
+   *   The name of the button, such as `drupallink`, `source`, etc.
+   */
+  protected function assertEditorButtonDisabled($name) {
+    $button = $this->getEditorButton($name);
+    $this->assertTrue($button->hasClass('cke_button_disabled'));
+    $this->assertSame('true', $button->getAttribute('aria-disabled'));
+  }
+
+  /**
+   * Asserts a CKEditor button is enabled.
+   *
+   * @param string $name
+   *   The name of the button, such as `drupallink`, `source`, etc.
+   */
+  protected function assertEditorButtonEnabled($name) {
+    $button = $this->getEditorButton($name);
+    $this->assertFalse($button->hasClass('cke_button_disabled'));
+    $this->assertSame('false', $button->getAttribute('aria-disabled'));
+  }
+
+}

--- a/core/modules/datetime/tests/src/Unit/Plugin/migrate/field/DateFieldLegacyTest.php
+++ b/core/modules/datetime/tests/src/Unit/Plugin/migrate/field/DateFieldLegacyTest.php
@@ -2,17 +2,30 @@
 
 namespace Drupal\Tests\datetime\Unit\Plugin\migrate\field;
 
+use Drupal\datetime\Plugin\migrate\field\DateField;
+use Drupal\migrate\MigrateException;
+use Drupal\Tests\UnitTestCase;
+
 /**
+ * Tests legacy methods on the date_field plugin.
+ *
  * @group migrate
  * @group legacy
  */
-class DateFieldLegacyTest extends DateFieldTest {
+class DateFieldLegacyTest extends UnitTestCase {
 
   /**
+   * Tests deprecation on calling processFieldValues().
+   *
    * @expectedDeprecation Deprecated in Drupal 8.6.0, to be removed before Drupal 9.0.0. Use defineValueProcessPipeline() instead. See https://www.drupal.org/node/2944598.
    */
-  public function testUnknownDateType($method = 'processFieldValues') {
-    parent::testUnknownDateType($method);
+  public function testUnknownDateType() {
+    $migration = $this->prophesize('Drupal\migrate\Plugin\MigrationInterface')->reveal();
+    $plugin = new DateField([], '', []);
+
+    $this->expectException(MigrateException::class);
+    $this->expectExceptionMessage("Field field_date of type 'timestamp' is an unknown date field type.");
+    $plugin->processFieldValues($migration, 'field_date', ['type' => 'timestamp']);
   }
 
 }

--- a/core/modules/datetime/tests/src/Unit/Plugin/migrate/field/DateFieldTest.php
+++ b/core/modules/datetime/tests/src/Unit/Plugin/migrate/field/DateFieldTest.php
@@ -7,19 +7,84 @@ use Drupal\migrate\MigrateException;
 use Drupal\Tests\UnitTestCase;
 
 /**
+ * Provides unit tests for the DateField Plugin.
+ *
+ * @coversDefaultClass \Drupal\datetime\Plugin\migrate\field\DateField
+ *
  * @group migrate
  */
 class DateFieldTest extends UnitTestCase {
 
   /**
-   * Tests an Exception is thrown when the field type is not a known date type.
+   * Tests defineValueProcessPipeline.
+   *
+   * @covers ::defineValueProcessPipeline
+   *
+   * @dataProvider providerTestDefineValueProcessPipeline
    */
-  public function testUnknownDateType($method = 'defineValueProcessPipeline') {
-    $migration = $this->prophesize('Drupal\migrate\Plugin\MigrationInterface')->reveal();
+  public function testDefineValueProcessPipeline($data, $from_format, $to_format) {
+    $migration = $this->createMock('Drupal\migrate\Plugin\MigrationInterface');
+    $migration->expects($this->once())
+      ->method('mergeProcessOfProperty')
+      ->with('field_date', [
+        'plugin' => 'sub_process',
+        'source' => 'field_date',
+        'process' => [
+          'value' => [
+            'plugin' => 'format_date',
+            'from_format' => $from_format,
+            'to_format' => $to_format,
+            'source' => 'value',
+          ],
+        ],
+      ])
+      ->will($this->returnValue($migration));
+
+    $plugin = new DateField([], '', []);
+    $plugin->defineValueProcessPipeline($migration, 'field_date', $data);
+  }
+
+  /**
+   * Provides data for testDefineValueProcessPipeline().
+   */
+  public function providerTestDefineValueProcessPipeline() {
+    return [
+      [['type' => 'date'], 'Y-m-d\TH:i:s', 'Y-m-d\TH:i:s'],
+      [['type' => 'datestamp'], 'U', 'U'],
+      [['type' => 'datetime'], 'Y-m-d H:i:s', 'Y-m-d\TH:i:s'],
+      [
+        [
+          'type' => 'datetime',
+          'field_definition' => [
+            'data' => serialize([
+              'settings' => [
+                'granularity' => [
+                  'hour' => 0,
+                  'minute' => 0,
+                  'second' => 0,
+                ],
+              ],
+            ]),
+          ],
+        ],
+        'Y-m-d H:i:s',
+        'Y-m-d',
+      ],
+    ];
+  }
+
+  /**
+   * Tests invalid date types throw an exception.
+   *
+   * @covers ::defineValueProcessPipeline
+   */
+  public function testDefineValueProcessPipelineException() {
+    $migration = $this->createMock('Drupal\migrate\Plugin\MigrationInterface');
+
     $plugin = new DateField([], '', []);
 
-    $this->setExpectedException(MigrateException::class, "Field field_date of type 'timestamp' is an unknown date field type.");
-    $plugin->$method($migration, 'field_date', ['type' => 'timestamp']);
+    $this->expectException(MigrateException::class);
+    $plugin->defineValueProcessPipeline($migration, 'field_date', ['type' => 'totoro']);
   }
 
 }

--- a/core/modules/field/src/Plugin/migrate/process/d7/FieldInstanceSettings.php
+++ b/core/modules/field/src/Plugin/migrate/process/d7/FieldInstanceSettings.php
@@ -65,6 +65,16 @@ class FieldInstanceSettings extends ProcessPluginBase {
       $instance_settings['handler_settings'] = $field_settings['handler_settings'];
     }
 
+    // Get the labels for the list_boolean type.
+    if ($row->getSourceProperty('type') === 'list_boolean') {
+      if (isset($field_data['settings']['allowed_values'][1])) {
+        $instance_settings['on_label'] = $field_data['settings']['allowed_values'][1];
+      }
+      if (isset($field_data['settings']['allowed_values'][0])) {
+        $instance_settings['off_label'] = $field_data['settings']['allowed_values'][0];
+      }
+    }
+
     switch ($widget_type) {
       case 'image_image':
         $settings = $instance_settings;

--- a/core/modules/field/tests/src/Kernel/Migrate/d7/MigrateFieldInstanceTest.php
+++ b/core/modules/field/tests/src/Kernel/Migrate/d7/MigrateFieldInstanceTest.php
@@ -150,6 +150,13 @@ class MigrateFieldInstanceTest extends MigrateDrupal7TestBase {
     $this->assertNull($name_field);
     $description_field = FieldConfig::load('taxonomy_term.test_vocabulary.description_field');
     $this->assertNull($description_field);
+
+    $boolean_field = FieldConfig::load('node.test_content_type.field_boolean');
+    $expected_settings = [
+      'on_label' => '1',
+      'off_label' => 'Off',
+    ];
+    $this->assertSame($expected_settings, $boolean_field->get('settings'));
   }
 
   /**

--- a/core/modules/image/src/Entity/ImageStyle.php
+++ b/core/modules/image/src/Entity/ImageStyle.php
@@ -182,7 +182,10 @@ class ImageStyle extends ConfigEntityBase implements ImageStyleInterface, Entity
       // source files not stored in the default scheme.
       if ($source_scheme != $default_scheme) {
         $class = $this->getStreamWrapperManager()->getClass($source_scheme);
-        $is_writable = $class::getType() & StreamWrapperInterface::WRITE;
+        $is_writable = NULL;
+        if ($class) {
+          $is_writable = $class::getType() & StreamWrapperInterface::WRITE;
+        }
 
         // Compute the derivative URI scheme. Derivatives created from writable
         // source stream wrappers will inherit the scheme. Derivatives created

--- a/core/modules/jsonapi/src/ParamConverter/EntityUuidConverter.php
+++ b/core/modules/jsonapi/src/ParamConverter/EntityUuidConverter.php
@@ -2,11 +2,10 @@
 
 namespace Drupal\jsonapi\ParamConverter;
 
-use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\ParamConverter\EntityConverter;
-use Drupal\Core\TypedData\TranslatableInterface;
 use Drupal\jsonapi\Routing\Routes;
 use Symfony\Cmf\Component\Routing\RouteObjectInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -62,7 +61,7 @@ class EntityUuidConverter extends EntityConverter {
       $entity = reset($entities);
       // If the entity type is translatable, ensure we return the proper
       // translation object for the current context.
-      if ($entity instanceof EntityInterface && $entity instanceof TranslatableInterface) {
+      if ($entity instanceof TranslatableInterface && $entity->isTranslatable()) {
         // @see https://www.drupal.org/project/drupal/issues/2624770
         $entity_repository = isset($this->entityRepository) ? $this->entityRepository : $this->entityManager;
         $entity = $entity_repository->getTranslationFromContext($entity, NULL, ['operation' => 'entity_upcast']);

--- a/core/modules/jsonapi/src/ResourceType/ResourceTypeRepository.php
+++ b/core/modules/jsonapi/src/ResourceType/ResourceTypeRepository.php
@@ -102,7 +102,7 @@ class ResourceTypeRepository implements ResourceTypeRepositoryInterface {
       $resource_types = [];
       foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
         $resource_types = array_merge($resource_types, array_map(function ($bundle) use ($entity_type) {
-          return $this->createResourceType($entity_type, $bundle);
+          return $this->createResourceType($entity_type, (string) $bundle);
         }, array_keys($this->entityTypeBundleInfo->getBundleInfo($entity_type->id()))));
       }
       foreach ($resource_types as $resource_type) {

--- a/core/modules/jsonapi/tests/src/Functional/JsonApiFunctionalMultilingualTest.php
+++ b/core/modules/jsonapi/tests/src/Functional/JsonApiFunctionalMultilingualTest.php
@@ -26,6 +26,7 @@ class JsonApiFunctionalMultilingualTest extends JsonApiFunctionalTestBase {
    */
   public static $modules = [
     'language',
+    'content_translation',
   ];
 
   /**
@@ -44,6 +45,13 @@ class JsonApiFunctionalMultilingualTest extends JsonApiFunctionalTestBase {
     \Drupal::configFactory()->getEditable('language.negotiation')
       ->set('url.prefixes.ca', 'ca')
       ->set('url.prefixes.ca-fr', 'ca-fr')
+      ->save();
+
+    ContentLanguageSettings::create([
+      'target_entity_type_id' => 'node',
+      'target_bundle' => 'article',
+    ])
+      ->setThirdPartySetting('content_translation', 'enabled', TRUE)
       ->save();
 
     $this->createDefaultContent(5, 5, TRUE, TRUE, static::IS_MULTILINGUAL, FALSE);
@@ -139,10 +147,8 @@ class JsonApiFunctionalMultilingualTest extends JsonApiFunctionalTestBase {
 
     // Specifying a langcode is allowed once configured to be alterable. But
     // modifying the language of a non-default translation is still not allowed.
-    ContentLanguageSettings::create([
-      'target_entity_type_id' => 'node',
-      'target_bundle' => 'article',
-    ])->setLanguageAlterable(TRUE)
+    ContentLanguageSettings::loadByEntityTypeBundle('node', 'article')
+      ->setLanguageAlterable(TRUE)
       ->save();
     $response = $this->request('PATCH', Url::fromUri('base:/ca/jsonapi/node/article/' . $this->nodes[0]->uuid()), $request_options);
     $this->assertSame(500, $response->getStatusCode());
@@ -267,10 +273,8 @@ class JsonApiFunctionalMultilingualTest extends JsonApiFunctionalTestBase {
 
     // Specifying a langcode is allowed once configured to be alterable. Now an
     // entity can be created with the specified langcode.
-    ContentLanguageSettings::create([
-      'target_entity_type_id' => 'node',
-      'target_bundle' => 'article',
-    ])->setLanguageAlterable(TRUE)
+    ContentLanguageSettings::loadByEntityTypeBundle('node', 'article')
+      ->setLanguageAlterable(TRUE)
       ->save();
     $request_document['data']['attributes']['langcode'] = 'ca';
     $request_options[RequestOptions::BODY] = Json::encode($request_document);

--- a/core/modules/jsonapi/tests/src/Functional/JsonApiRegressionTest.php
+++ b/core/modules/jsonapi/tests/src/Functional/JsonApiRegressionTest.php
@@ -6,9 +6,12 @@ use Drupal\comment\Entity\Comment;
 use Drupal\comment\Plugin\Field\FieldType\CommentItemInterface;
 use Drupal\comment\Tests\CommentTestTrait;
 use Drupal\Component\Serialization\Json;
+use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\datetime\Plugin\Field\FieldType\DateTimeItem;
+use Drupal\entity_test\Entity\EntityTest;
 use Drupal\entity_test\Entity\EntityTestMapField;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
@@ -988,6 +991,67 @@ class JsonApiRegressionTest extends JsonApiFunctionalTestBase {
     // Requesting the comment collection should succeed.
     $response = $this->request('GET', Url::fromUri('internal:/jsonapi/comment/comment'), $request_options);
     $this->assertSame(200, $response->getStatusCode());
+  }
+
+  /**
+   * Ensure non-translatable entities can be PATCHed with an alternate language.
+   *
+   * @see https://www.drupal.org/project/drupal/issues/3043168
+   */
+  public function testNonTranslatableEntityUpdatesFromIssue3043168() {
+    // Enable write-mode.
+    $this->config('jsonapi.settings')->set('read_only', FALSE)->save(TRUE);
+    // Set the site language to Russian.
+    $this->config('system.site')->set('langcode', 'ru')->set('default_langcode', 'ru')->save(TRUE);
+    // Install a "custom" entity type that is not translatable.
+    $this->assertTrue($this->container->get('module_installer')->install(['entity_test'], TRUE), 'Installed modules.');
+    // Clear and rebuild caches and routes.
+    $this->rebuildAll();
+    // Create a test entity.
+    // @see \Drupal\language\DefaultLanguageItem
+    $entity = EntityTest::create([
+      'name' => 'Alexander',
+      'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+    ]);
+    $entity->save();
+    // Ensure it is an instance of TranslatableInterface and that it is *not*
+    // translatable.
+    $this->assertInstanceOf(TranslatableInterface::class, $entity);
+    $this->assertFalse($entity->isTranslatable());
+    // Set up a test user with permission to view and update the test entity.
+    $user = $this->drupalCreateUser(['view test entity', 'administer entity_test content']);
+    $request_options[RequestOptions::HEADERS]['Accept'] = 'application/vnd.api+json';
+    $request_options[RequestOptions::AUTH] = [
+      $user->getUsername(),
+      $user->pass_raw,
+    ];
+    // GET the test entity via JSON:API.
+    $entity_url = Url::fromUri('internal:/jsonapi/entity_test/entity_test/' . $entity->uuid());
+    $response = $this->request('GET', $entity_url, $request_options);
+    $this->assertSame(200, $response->getStatusCode());
+    $response_document = Json::decode($response->getBody());
+    // Ensure that the entity's langcode attribute is 'und'.
+    $this->assertSame(LanguageInterface::LANGCODE_NOT_SPECIFIED, $response_document['data']['attributes']['langcode']);
+    // Prepare to PATCH the entity via JSON:API.
+    $request_options[RequestOptions::HEADERS]['Content-Type'] = 'application/vnd.api+json';
+    $request_options[RequestOptions::JSON] = [
+      'data' => [
+        'type' => 'entity_test--entity_test',
+        'id' => $entity->uuid(),
+        'attributes' => [
+          'name' => 'Constantine',
+        ],
+      ],
+    ];
+    // Issue the PATCH request and verify that the test entity was successfully
+    // updated.
+    $response = $this->request('PATCH', $entity_url, $request_options);
+    $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+    $response_document = Json::decode($response->getBody());
+    // Ensure that the entity's langcode attribute is still 'und' and the name
+    // was successfully updated.
+    $this->assertSame(LanguageInterface::LANGCODE_NOT_SPECIFIED, $response_document['data']['attributes']['langcode']);
+    $this->assertSame('Constantine', $response_document['data']['attributes']['name']);
   }
 
 }

--- a/core/modules/jsonapi/tests/src/Kernel/ResourceType/ResourceTypeRepositoryTest.php
+++ b/core/modules/jsonapi/tests/src/Kernel/ResourceType/ResourceTypeRepositoryTest.php
@@ -51,6 +51,9 @@ class ResourceTypeRepositoryTest extends KernelTestBase {
     NodeType::create([
       'type' => 'page',
     ])->save();
+    NodeType::create([
+      'type' => '42',
+    ])->save();
 
     $this->resourceTypeRepository = $this->container->get('jsonapi.resource_type.repository');
   }
@@ -92,6 +95,7 @@ class ResourceTypeRepositoryTest extends KernelTestBase {
   public function getProvider() {
     return [
       ['node', 'article', 'Drupal\node\Entity\Node'],
+      ['node', '42', 'Drupal\node\Entity\Node'],
       ['node_type', 'node_type', 'Drupal\node\Entity\NodeType'],
       ['menu', 'menu', 'Drupal\system\Entity\Menu'],
     ];

--- a/core/modules/media/tests/src/Kernel/MediaSourceFileTest.php
+++ b/core/modules/media/tests/src/Kernel/MediaSourceFileTest.php
@@ -27,4 +27,21 @@ class MediaSourceFileTest extends MediaKernelTestBase {
     $this->assertCount(0, $result);
   }
 
+  /**
+   * Tests a media file can be deleted.
+   */
+  public function testFileDeletion() {
+    $mediaType = $this->createMediaType('file');
+    $media = $this->generateMedia('test.txt', $mediaType);
+    $media->save();
+
+    $source_field_name = $mediaType->getSource()
+      ->getSourceFieldDefinition($mediaType)
+      ->getName();
+    /** @var \Drupal\file\FileInterface $file */
+    $file = $media->get($source_field_name)->entity;
+    $file->delete();
+    $this->assertEmpty($this->container->get('entity_type.manager')->getStorage('file')->loadByProperties(['filename' => 'test.txt']));
+  }
+
 }

--- a/core/modules/node/tests/src/Kernel/Migrate/d7/MigrateNodeTest.php
+++ b/core/modules/node/tests/src/Kernel/Migrate/d7/MigrateNodeTest.php
@@ -149,6 +149,9 @@ class MigrateNodeTest extends MigrateDrupal7TestBase {
     $node = Node::load(1);
     $this->assertTrue($node->field_boolean->value);
     $this->assertEquals('99-99-99-99', $node->field_phone->value);
+    $this->assertSame('2015-01-20T04:15:00', $node->field_date->value);
+    $this->assertSame('2015-01-20', $node->field_date_without_time->value);
+    $this->assertSame('2015-01-20', $node->field_datetime_without_time->value);
     $this->assertEquals('1', $node->field_float->value);
     $this->assertEquals('5', $node->field_integer->value);
     $this->assertEquals('Some more text', $node->field_text_list[0]->value);

--- a/core/modules/options/src/Plugin/migrate/field/d6/OptionWidgetsField.php
+++ b/core/modules/options/src/Plugin/migrate/field/d6/OptionWidgetsField.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\options\Plugin\migrate\field\d7;
+namespace Drupal\options\Plugin\migrate\field\d6;
 
 use Drupal\migrate_drupal\Plugin\migrate\field\FieldPluginBase;
 

--- a/core/modules/system/js/system.date.es6.js
+++ b/core/modules/system/js/system.date.es6.js
@@ -43,7 +43,7 @@
           (key, value) => (dateFormats[key] ? dateFormats[key] : value),
         );
 
-        $preview.html(dateString);
+        $preview.text(dateString);
         $target.toggleClass('js-hide', !dateString.length);
       }
 

--- a/core/modules/system/js/system.date.js
+++ b/core/modules/system/js/system.date.js
@@ -25,7 +25,7 @@
           return dateFormats[key] ? dateFormats[key] : value;
         });
 
-        $preview.html(dateString);
+        $preview.text(dateString);
         $target.toggleClass('js-hide', !dateString.length);
       }
 

--- a/core/modules/system/src/Controller/SystemController.php
+++ b/core/modules/system/src/Controller/SystemController.php
@@ -222,8 +222,6 @@ class SystemController extends ControllerBase {
       }
 
       if (empty($theme->status)) {
-        // Ensure this theme is compatible with this version of core.
-        $theme->incompatible_core = !isset($theme->info['core']) || ($theme->info['core'] != \DRUPAL::CORE_COMPATIBILITY);
         // Require the 'content' region to make sure the main page
         // content has a common place in all themes.
         $theme->incompatible_region = !isset($theme->info['regions']['content']);
@@ -234,7 +232,7 @@ class SystemController extends ControllerBase {
         $theme->incompatible_engine = isset($theme->info['engine']) && !isset($theme->owner);
       }
       $theme->operations = [];
-      if (!empty($theme->status) || !$theme->incompatible_core && !$theme->incompatible_php && !$theme->incompatible_base && !$theme->incompatible_engine) {
+      if (!empty($theme->status) || !$theme->info['core_incompatible'] && !$theme->incompatible_php && !$theme->incompatible_base && !$theme->incompatible_engine) {
         // Create the operations links.
         $query['theme'] = $theme->getName();
         if ($this->themeAccess->checkAccess($theme->getName())) {

--- a/core/modules/system/src/Form/ModulesListForm.php
+++ b/core/modules/system/src/Form/ModulesListForm.php
@@ -281,10 +281,14 @@ class ModulesListForm extends FormBase {
     $reasons = [];
 
     // Check the core compatibility.
-    if ($module->info['core'] != \Drupal::CORE_COMPATIBILITY) {
+    if ($module->info['core_incompatible']) {
       $compatible = FALSE;
       $reasons[] = $this->t('This version is not compatible with Drupal @core_version and should be replaced.', [
-        '@core_version' => \Drupal::CORE_COMPATIBILITY,
+        '@core_version' => \Drupal::VERSION,
+      ]);
+      $row['#requires']['core'] = $this->t('Drupal Core (@core_requirement) (<span class="admin-missing">incompatible with</span> version @core_version)', [
+        '@core_requirement' => isset($module->info['core_version_requirement']) ? $module->info['core_version_requirement'] : $module->info['core'],
+        '@core_version' => \Drupal::VERSION,
       ]);
     }
 
@@ -328,7 +332,7 @@ class ModulesListForm extends FormBase {
         }
         // Disable the checkbox if the dependency is incompatible with this
         // version of Drupal core.
-        elseif ($modules[$dependency]->info['core'] != \Drupal::CORE_COMPATIBILITY) {
+        elseif ($modules[$dependency]->info['core_incompatible']) {
           $row['#requires'][$dependency] = $this->t('@module (<span class="admin-missing">incompatible with</span> this version of Drupal core)', [
             '@module' => $name,
           ]);

--- a/core/modules/system/system.admin.inc
+++ b/core/modules/system/system.admin.inc
@@ -292,8 +292,8 @@ function template_preprocess_system_themes_page(&$variables) {
 
       // Make sure to provide feedback on compatibility.
       $current_theme['incompatible'] = '';
-      if (!empty($theme->incompatible_core)) {
-        $current_theme['incompatible'] = t("This theme is not compatible with Drupal @core_version. Check that the .info.yml file contains the correct 'core' value.", ['@core_version' => \Drupal::CORE_COMPATIBILITY]);
+      if (!empty($theme->info['core_incompatible'])) {
+        $current_theme['incompatible'] = t("This theme is not compatible with Drupal @core_version. Check that the .info.yml file contains a compatible 'core' or 'core_version_requirement' value.", ['@core_version' => \Drupal::VERSION]);
       }
       elseif (!empty($theme->incompatible_region)) {
         $current_theme['incompatible'] = t("This theme is missing a 'content' region.");

--- a/core/modules/system/tests/fixtures/update/drupal-8.update-test-semver-update-n-enabled.php
+++ b/core/modules/system/tests/fixtures/update/drupal-8.update-test-semver-update-n-enabled.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * @file
+ * Database to mimic the installation of the update_test_semver_update_n module.
+ */
+
+use Drupal\Core\Database\Database;
+
+$connection = Database::getConnection();
+
+// Set the schema version.
+$connection->merge('key_value')
+  ->condition('collection', 'system.schema')
+  ->condition('name', 'update_test_semver_update_n')
+  ->fields([
+    'collection' => 'system.schema',
+    'name' => 'update_test_semver_update_n',
+    'value' => 'i:8000;',
+  ])
+  ->execute();
+
+// Update core.extension.
+$extensions = $connection->select('config')
+  ->fields('config', ['data'])
+  ->condition('collection', '')
+  ->condition('name', 'core.extension')
+  ->execute()
+  ->fetchField();
+$extensions = unserialize($extensions);
+$extensions['module']['update_test_semver_update_n'] = 8000;
+$connection->update('config')
+  ->fields([
+    'data' => serialize($extensions),
+  ])
+  ->condition('collection', '')
+  ->condition('name', 'core.extension')
+  ->execute();

--- a/core/modules/system/tests/modules/system_core_incompatible_semver_test/system_core_incompatible_semver_test.info.yml
+++ b/core/modules/system/tests/modules/system_core_incompatible_semver_test/system_core_incompatible_semver_test.info.yml
@@ -1,0 +1,6 @@
+name: 'System core incompatible semver test'
+type: module
+description: 'Support module for testing core incompatible semver.'
+package: Testing
+version: 1.0.0
+core_version_requirement: ^7

--- a/core/modules/system/tests/modules/system_core_semver_test/system_core_semver_test.info.yml
+++ b/core/modules/system/tests/modules/system_core_semver_test/system_core_semver_test.info.yml
@@ -1,0 +1,6 @@
+name: 'System core ^8 version test'
+type: module
+description: 'Support module for testing core using semver.'
+package: Testing
+version: 1.0.0
+core_version_requirement: ^8

--- a/core/modules/system/tests/modules/system_incompatible_core_version_test_1x/system_incompatible_core_version_test_1x.info.yml
+++ b/core/modules/system/tests/modules/system_incompatible_core_version_test_1x/system_incompatible_core_version_test_1x.info.yml
@@ -1,0 +1,6 @@
+name: 'System incompatible core 1.x version test'
+type: module
+description: 'Support module for testing system core incompatibility.'
+package: Testing
+version: 1.0.0
+core: 1.x

--- a/core/modules/system/tests/modules/system_test/system_test.module
+++ b/core/modules/system/tests/modules/system_test/system_test.module
@@ -71,6 +71,7 @@ function system_test_system_info_alter(&$info, Extension $file, $type) {
     'system_incompatible_core_version_dependencies_test',
     'system_incompatible_module_version_test',
     'system_incompatible_core_version_test',
+    'system_incompatible_core_version_test_1x',
   ])) {
     $info['hidden'] = FALSE;
   }

--- a/core/modules/system/tests/modules/update_test_semver_update_n/update_test_semver_update_n.info.yml
+++ b/core/modules/system/tests/modules/update_test_semver_update_n/update_test_semver_update_n.info.yml
@@ -1,0 +1,6 @@
+name: 'Update test hook_update_n semver'
+type: module
+description: 'Support module for update testing with core semver value.'
+package: Testing
+version: VERSION
+core_version_requirement: ^8

--- a/core/modules/system/tests/modules/update_test_semver_update_n/update_test_semver_update_n.install
+++ b/core/modules/system/tests/modules/update_test_semver_update_n/update_test_semver_update_n.install
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for the update_test_semver_update_n module.
+ */
+
+/**
+ * Update 8001.
+ */
+function update_test_semver_update_n_update_8001() {
+  \Drupal::state()->set('update_test_semver_update_n_update_8001', 'Yes, I was run. Thanks for testing!');
+}

--- a/core/modules/system/tests/src/Functional/Form/ModulesListFormWebTest.php
+++ b/core/modules/system/tests/src/Functional/Form/ModulesListFormWebTest.php
@@ -70,7 +70,7 @@ BROKEN;
 
     // Confirm that the error message is shown.
     $this->assertSession()
-      ->pageTextContains('Modules could not be listed due to an error: Missing required keys (core) in ' . $path . '/broken.info.yml');
+      ->pageTextContains("The 'core' or the 'core_version_requirement' key must be present in " . $path . '/broken.info.yml');
 
     // Check that the module filter text box is available.
     $this->assertTrue($this->xpath('//input[@name="text"]'));

--- a/core/modules/system/tests/src/Functional/Module/DependencyTest.php
+++ b/core/modules/system/tests/src/Functional/Module/DependencyTest.php
@@ -103,6 +103,29 @@ class DependencyTest extends ModuleTestBase {
   }
 
   /**
+   * Tests enabling modules with different core version specifications.
+   */
+  public function testCoreCompatibility() {
+    $assert_session = $this->assertSession();
+
+    // Test incompatible 'core_version_requirement'.
+    $this->drupalGet('admin/modules');
+    $assert_session->fieldDisabled('modules[system_incompatible_core_version_test_1x][enable]');
+    $assert_session->fieldDisabled('modules[system_core_incompatible_semver_test][enable]');
+
+    // Test compatible 'core_version_requirement' and compatible 'core'.
+    $this->drupalGet('admin/modules');
+    $assert_session->fieldEnabled('modules[common_test][enable]');
+    $assert_session->fieldEnabled('modules[system_core_semver_test][enable]');
+
+    // Ensure the modules can actually be installed.
+    $edit['modules[common_test][enable]'] = 'common_test';
+    $edit['modules[system_core_semver_test][enable]'] = 'system_core_semver_test';
+    $this->drupalPostForm('admin/modules', $edit, t('Install'));
+    $this->assertModules(['common_test', 'system_core_semver_test'], TRUE);
+  }
+
+  /**
    * Tests enabling a module that depends on a module which fails hook_requirements().
    */
   public function testEnableRequirementsFailureDependency() {

--- a/core/modules/system/tests/src/FunctionalJavascript/System/DateFormatTest.php
+++ b/core/modules/system/tests/src/FunctionalJavascript/System/DateFormatTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\Tests\system\FunctionalJavascript\System;
+
+use Drupal\Core\Datetime\Entity\DateFormat;
+use Drupal\FunctionalJavascriptTests\WebDriverTestBase;
+
+/**
+ * Tests that date formats UI with JavaScript enabled.
+ *
+ * @group system
+ */
+class DateFormatTest extends WebDriverTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['block'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+
+    // Create admin user and log in admin user.
+    $this->drupalLogin($this->drupalCreateUser(['administer site configuration']));
+    $this->drupalPlaceBlock('local_actions_block');
+  }
+
+  /**
+   * Tests XSS via date format configuration.
+   */
+  public function testDateFormatXss() {
+    $page = $this->getSession()->getPage();
+    $assert = $this->assertSession();
+
+    $date_format = DateFormat::create([
+      'id' => 'xss_short',
+      'label' => 'XSS format',
+      'pattern' => '\<\s\c\r\i\p\t\>\a\l\e\r\t\(\"\X\S\S\")\;\<\/\s\c\r\i\p\t\>',
+    ]);
+    $date_format->save();
+    $this->drupalGet('admin/config/regional/date-time');
+    $assert->assertEscaped('<script>alert("XSS");</script>', 'The date format was properly escaped');
+    $this->drupalGet('admin/config/regional/date-time/formats/manage/xss_short');
+    $assert->assertEscaped('<script>alert("XSS");</script>', 'The date format was properly escaped');
+
+    // Add a new date format with HTML in it.
+    $this->drupalGet('admin/config/regional/date-time/formats/add');
+    $date_format = '& \<\e\m\>Y\<\/\e\m\>';
+    $page->fillField('date_format_pattern', $date_format);
+    $assert->waitForText('Displayed as');
+    $assert->assertEscaped('<em>' . date("Y") . '</em>');
+    $page->fillField('label', 'date_html_pattern');
+    // Wait for the machine name ID to be completed.
+    $assert->waitForLink('Edit');
+    $page->pressButton('Add format');
+    $assert->pageTextContains('Custom date format added.');
+    $assert->assertEscaped('<em>' . date("Y") . '</em>');
+  }
+
+}

--- a/core/modules/system/tests/themes/test_core_semver/test_core_semver.info.yml
+++ b/core/modules/system/tests/themes/test_core_semver/test_core_semver.info.yml
@@ -1,0 +1,5 @@
+name: 'Theme test with semver core version'
+type: theme
+description: 'Test theme which has semver core version.'
+version: VERSION
+core_version_requirement: ^8 || ^9

--- a/core/modules/system/tests/themes/test_invalid_core_semver/test_invalid_core_semver.info.yml
+++ b/core/modules/system/tests/themes/test_invalid_core_semver/test_invalid_core_semver.info.yml
@@ -1,0 +1,5 @@
+name: 'Theme test with invalid semver core version'
+type: theme
+description: 'Test theme which has an invalid semver core version.'
+version: VERSION
+core_version_requirement: ^7

--- a/core/modules/update/update.module
+++ b/core/modules/update/update.module
@@ -696,7 +696,7 @@ function update_verify_update_archive($project, $archive_file, $directory) {
     $info = \Drupal::service('info_parser')->parse($file->uri);
 
     // If the module or theme is incompatible with Drupal core, set an error.
-    if (empty($info['core']) || $info['core'] != \Drupal::CORE_COMPATIBILITY) {
+    if ($info['core_incompatible']) {
       $incompatible[] = !empty($info['name']) ? $info['name'] : t('Unknown');
     }
     else {
@@ -716,7 +716,7 @@ function update_verify_update_archive($project, $archive_file, $directory) {
       '%archive_file contains a version of %names that is not compatible with Drupal @version.',
       '%archive_file contains versions of modules or themes that are not compatible with Drupal @version: %names',
       [
-        '@version' => \Drupal::CORE_COMPATIBILITY,
+        '@version' => \Drupal::VERSION,
         '%archive_file' => $file_system->basename($archive_file),
         '%names' => implode(', ', $incompatible),
       ]

--- a/core/modules/views/src/EventSubscriber/ViewsEntitySchemaSubscriber.php
+++ b/core/modules/views/src/EventSubscriber/ViewsEntitySchemaSubscriber.php
@@ -306,7 +306,7 @@ class ViewsEntitySchemaSubscriber implements EntityTypeListenerInterface, EventS
       }
     }
 
-    $this->processHandlers($all_views, function (array &$handler_config, ViewEntityInterface $view) use ($entity_type_id, $old_base_table, $new_base_table) {
+    $this->processHandlers($all_views, function (&$handler_config, ViewEntityInterface $view) use ($entity_type_id, $old_base_table, $new_base_table) {
       if (isset($handler_config['entity_type']) && $handler_config['entity_type'] == $entity_type_id && $handler_config['table'] == $old_base_table) {
         $handler_config['table'] = $new_base_table;
         $view->set('_updated', TRUE);
@@ -334,7 +334,7 @@ class ViewsEntitySchemaSubscriber implements EntityTypeListenerInterface, EventS
       }
     }
 
-    $this->processHandlers($all_views, function (array &$handler_config, ViewEntityInterface $view) use ($entity_type_id, $old_data_table, $new_data_table) {
+    $this->processHandlers($all_views, function (&$handler_config, ViewEntityInterface $view) use ($entity_type_id, $old_data_table, $new_data_table) {
       if (isset($handler_config['entity_type']) && $handler_config['entity_type'] == $entity_type_id && $handler_config['table'] == $old_data_table) {
         $handler_config['table'] = $new_data_table;
         $view->set('_updated', TRUE);
@@ -365,7 +365,7 @@ class ViewsEntitySchemaSubscriber implements EntityTypeListenerInterface, EventS
 
     $data_table = $new_data_table;
 
-    $this->processHandlers($all_views, function (array &$handler_config, ViewEntityInterface $view) use ($entity_type_id, $base_table, $data_table, $base_table_fields, $data_table_fields) {
+    $this->processHandlers($all_views, function (&$handler_config, ViewEntityInterface $view) use ($entity_type_id, $base_table, $data_table, $base_table_fields, $data_table_fields) {
       if (isset($handler_config['entity_type']) && isset($handler_config['entity_field']) && $handler_config['entity_type'] == $entity_type_id) {
         // Move all fields which just exists on the data table.
         if ($handler_config['table'] == $base_table && in_array($handler_config['entity_field'], $data_table_fields) && !in_array($handler_config['entity_field'], $base_table_fields)) {
@@ -390,7 +390,7 @@ class ViewsEntitySchemaSubscriber implements EntityTypeListenerInterface, EventS
    */
   protected function dataTableRemoval($all_views, $entity_type_id, $old_data_table, $base_table) {
     // We move back the data table back to the base table.
-    $this->processHandlers($all_views, function (array &$handler_config, ViewEntityInterface $view) use ($entity_type_id, $old_data_table, $base_table) {
+    $this->processHandlers($all_views, function (&$handler_config, ViewEntityInterface $view) use ($entity_type_id, $old_data_table, $base_table) {
       if (isset($handler_config['entity_type']) && $handler_config['entity_type'] == $entity_type_id) {
         if ($handler_config['table'] == $old_data_table) {
           $handler_config['table'] = $base_table;

--- a/core/modules/views/tests/modules/views_test_config/views_test_config.module
+++ b/core/modules/views/tests/modules/views_test_config/views_test_config.module
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Contains the "views_test_config" module main functionality.
+ */
+
+/**
+ * Implements hook_ENTITY_TYPE_load().
+ */
+function views_test_config_view_load(array $views) {
+  // Emulate a severely broken view: this kind of view configuration cannot be
+  // saved, it can likely be returned only by a corrupt active configuration.
+  $broken_view_id = \Drupal::state()->get('views_test_config.broken_view');
+  if (isset($views[$broken_view_id])) {
+    $display =& $views[$broken_view_id]->getDisplay('default');
+    $display['display_options']['fields']['id_broken'] = NULL;
+  }
+}

--- a/core/modules/views/tests/src/Kernel/EventSubscriber/ViewsEntitySchemaSubscriberIntegrationTest.php
+++ b/core/modules/views/tests/src/Kernel/EventSubscriber/ViewsEntitySchemaSubscriberIntegrationTest.php
@@ -502,6 +502,25 @@ class ViewsEntitySchemaSubscriberIntegrationTest extends ViewsKernelTestBase {
   }
 
   /**
+   * Tests that broken views are handled gracefully.
+   */
+  public function testBrokenView() {
+    $view_id = 'test_view_entity_test';
+    $this->state->set('views_test_config.broken_view', $view_id);
+    $this->updateEntityTypeToTranslatable(TRUE);
+
+    /** @var \Drupal\views\Entity\View $view */
+    $entity_storage = $this->entityTypeManager->getStorage('view');
+    $view = $entity_storage->load($view_id);
+
+    // The broken handler should have been removed.
+    $display = $view->getDisplay('default');
+    $this->assertFalse(isset($display['display_options']['fields']['id_broken']));
+
+    $this->assertUpdatedViews([$view_id]);
+  }
+
+  /**
    * Gets a view and its display.
    *
    * @param bool $revision

--- a/core/modules/workspaces/src/Form/WorkspaceActivateForm.php
+++ b/core/modules/workspaces/src/Form/WorkspaceActivateForm.php
@@ -107,7 +107,6 @@ class WorkspaceActivateForm extends EntityConfirmFormBase implements WorkspaceFo
     try {
       $this->workspaceManager->setActiveWorkspace($this->entity);
       $this->messenger->addMessage($this->t('%workspace_label is now the active workspace.', ['%workspace_label' => $this->entity->label()]));
-      $form_state->setRedirect('<front>');
     }
     catch (WorkspaceAccessException $e) {
       $this->messenger->addError($this->t('You do not have access to activate the %workspace_label workspace.', ['%workspace_label' => $this->entity->label()]));

--- a/core/modules/workspaces/src/WorkspaceListBuilder.php
+++ b/core/modules/workspaces/src/WorkspaceListBuilder.php
@@ -208,7 +208,7 @@ class WorkspaceListBuilder extends EntityListBuilder {
     $rows = array_slice($build['table']['#rows'], 0, 5, TRUE);
     foreach ($rows as $id => $row) {
       if ($active_workspace->id() !== $id) {
-        $url = Url::fromRoute('entity.workspace.activate_form', ['workspace' => $id]);
+        $url = Url::fromRoute('entity.workspace.activate_form', ['workspace' => $id], ['query' => $this->getDestinationArray()]);
         $default_class = $id === WorkspaceInterface::DEFAULT_WORKSPACE ? 'workspaces__item--default' : 'workspaces__item--not-default';
         $items[] = [
           '#type' => 'link',

--- a/core/modules/workspaces/tests/src/FunctionalJavascript/WorkspaceToolbarIntegrationTest.php
+++ b/core/modules/workspaces/tests/src/FunctionalJavascript/WorkspaceToolbarIntegrationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\Tests\workspaces\FunctionalJavascript;
+
+use Drupal\Tests\system\FunctionalJavascript\OffCanvasTestBase;
+
+/**
+ * Tests workspace settings stray integration.
+ *
+ * @group workspaces
+ */
+class WorkspaceToolbarIntegrationTest extends OffCanvasTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['toolbar', 'workspaces'];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setUp();
+    $admin_user = $this->drupalCreateUser([
+      'administer workspaces',
+      'access toolbar',
+      'access administration pages',
+    ]);
+    $this->drupalLogin($admin_user);
+  }
+
+  /**
+   * Test workspace canvas can be toggled with JavaScript.
+   */
+  public function testWorkspaceCanvasToggling() {
+    $page = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+
+    // Set size for horizontal toolbar.
+    $this->getSession()->resizeWindow(1200, 600);
+    $this->drupalGet('<front>');
+    // Wait for toolbar to appear.
+    $this->assertNotEmpty($assert_session->waitForElement('css', 'body.toolbar-horizontal'));
+
+    // Open workspace canvas.
+    $page->clickLink('Switch workspace');
+    $this->waitForOffCanvasToOpen('top');
+    $assert_session->elementExists('css', '.workspaces-dialog');
+
+    // Close Canvas.
+    $page->pressButton('Close');
+    $this->waitForOffCanvasToClose();
+    $assert_session->assertNoElementAfterWait('css', '.workspaces-dialog');
+  }
+
+  /**
+   * Test workspace switch and landing page behaviour.
+   */
+  public function testWorkspaceSwitch() {
+    $page = $this->getSession()->getPage();
+    $assert_session = $this->assertSession();
+
+    // Wait for toolbar to appear.
+    $this->getSession()->resizeWindow(1200, 600);
+    $this->drupalGet('admin');
+
+    // Wait for toolbar to appear.
+    $this->assertNotEmpty($assert_session->waitForElement('css', 'body.toolbar-horizontal'));
+
+    // Open workspace canvas.
+    $page->clickLink('Switch workspace');
+    $this->waitForOffCanvasToOpen('top');
+
+    // Click 'stage' workspace and confirm switch.
+    $page->clickLink('Stage');
+    $this->assertElementVisibleAfterWait('css', '.workspace-activate-form.workspace-confirm-form');
+    $page->find('css', '.ui-dialog-buttonset .button--primary')->click();
+    $assert_session->waitForElementVisible('css', '.messages--status');
+
+    // Make sure we stay on same page after switch.
+    $assert_session->responseContains('<em class="placeholder">Stage</em> is now the active workspace.');
+    $assert_session->addressEquals('admin');
+  }
+
+}

--- a/core/modules/workspaces/workspaces.module
+++ b/core/modules/workspaces/workspaces.module
@@ -152,7 +152,6 @@ function workspaces_cron() {
  * Implements hook_toolbar().
  */
 function workspaces_toolbar() {
-  $items = [];
   $items['workspace'] = [
     '#cache' => [
       'contexts' => [
@@ -160,7 +159,6 @@ function workspaces_toolbar() {
       ],
     ],
   ];
-
   $current_user = \Drupal::currentUser();
   if (!$current_user->hasPermission('administer workspaces')
     && !$current_user->hasPermission('view own workspace')
@@ -176,7 +174,7 @@ function workspaces_toolbar() {
     'tab' => [
       '#type' => 'link',
       '#title' => $active_workspace->label(),
-      '#url' => $active_workspace->toUrl('collection'),
+      '#url' => $active_workspace->toUrl('collection', ['query' => \Drupal::destination()->getAsArray()]),
       '#attributes' => [
         'title' => t('Switch workspace'),
         'class' => ['use-ajax', 'toolbar-icon', 'toolbar-icon-workspace'],

--- a/core/phpunit.xml.dist
+++ b/core/phpunit.xml.dist
@@ -31,9 +31,13 @@
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value=''/>
   </php>
   <testsuites>
     <testsuite name="unit">

--- a/core/tests/Drupal/FunctionalTests/Update/UpdatePathTestBaseTest.php
+++ b/core/tests/Drupal/FunctionalTests/Update/UpdatePathTestBaseTest.php
@@ -26,6 +26,7 @@ class UpdatePathTestBaseTest extends UpdatePathTestBase {
     $this->databaseDumpFiles = [
       __DIR__ . '/../../../../modules/system/tests/fixtures/update/drupal-8.bare.standard.php.gz',
       __DIR__ . '/../../../../modules/system/tests/fixtures/update/drupal-8.update-test-schema-enabled.php',
+      __DIR__ . '/../../../../modules/system/tests/fixtures/update/drupal-8.update-test-semver-update-n-enabled.php',
     ];
   }
 
@@ -99,8 +100,11 @@ class UpdatePathTestBaseTest extends UpdatePathTestBase {
 
     // Ensure schema has changed.
     $this->assertEqual(drupal_get_installed_schema_version('update_test_schema', TRUE), 8001);
+    $this->assertEqual(drupal_get_installed_schema_version('update_test_semver_update_n', TRUE), 8001);
     // Ensure the index was added for column a.
     $this->assertTrue($connection->schema()->indexExists('update_test_schema_table', 'test'), 'Version 8001 of the update_test_schema module is installed.');
+    // Ensure update_test_semver_update_n_update_8001 was run.
+    $this->assertEquals(\Drupal::state()->get('update_test_semver_update_n_update_8001'), 'Yes, I was run. Thanks for testing!');
   }
 
   /**

--- a/core/tests/Drupal/KernelTests/Core/Entity/EntityDeriverTest.php
+++ b/core/tests/Drupal/KernelTests/Core/Entity/EntityDeriverTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\KernelTests\Core\Entity;
+
+use Drupal\comment\Entity\CommentType;
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests EntityDeriver functionality.
+ *
+ * @coversDefaultClass \Drupal\Core\Entity\Plugin\DataType\Deriver\EntityDeriver
+ *
+ * @group Entity
+ */
+class EntityDeriverTest extends KernelTestBase {
+
+  /**
+   * The typed data manager to use.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataManagerInterface
+   */
+  protected $typedDataManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'system',
+    'field',
+    'user',
+    'node',
+    'comment',
+    'entity_test',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() {
+    parent::setup();
+
+    $this->installEntitySchema('comment');
+    NodeType::create(['type' => 'article', 'name' => 'Article'])->save();
+    CommentType::create([
+      'id' => 'comment',
+      'name' => 'Default comment',
+      'target_entity_type_id' => 'node',
+    ])->save();
+    entity_test_create_bundle('foo', NULL, 'entity_test_no_bundle');
+    entity_test_create_bundle('entity_test_no_bundle', NULL, 'entity_test_no_bundle');
+    $this->typedDataManager = $this->container->get('typed_data_manager');
+  }
+
+  /**
+   * Tests that types are derived for entity types with and without bundles.
+   *
+   * @dataProvider derivativesProvider
+   */
+  public function testDerivatives($data_type, $expect_exception) {
+    if ($expect_exception) {
+      $this->setExpectedException(PluginNotFoundException::class);
+    }
+    $this->typedDataManager->createDataDefinition($data_type);
+  }
+
+  /**
+   * Provides test data for ::testDerivatives().
+   */
+  public function derivativesProvider() {
+    return [
+      'unbundleable entity type with no bundle type' => ['entity:user', FALSE],
+      'unbundleable entity type with bundle type' => ['entity:user:user', TRUE],
+      'bundleable entity type with no bundle type' => ['entity:node', FALSE],
+      'bundleable entity type with bundle type' => [
+        'entity:node:article',
+        FALSE,
+      ],
+      'bundleable entity type with bundle type with matching name' => [
+        'entity:comment:comment',
+        FALSE,
+      ],
+      'unbundleable entity type with entity_test_entity_bundle_info()-generated bundle type' => [
+        'entity:entity_test_no_bundle:foo',
+        FALSE,
+      ],
+      'unbundleable entity type with entity_test_entity_bundle_info()-generated bundle type with matching name' => [
+        'entity:entity_test_no_bundle:entity_test_no_bundle',
+        FALSE,
+      ],
+    ];
+  }
+
+}

--- a/core/tests/Drupal/KernelTests/Core/Entity/EntityTypedDataDefinitionTest.php
+++ b/core/tests/Drupal/KernelTests/Core/Entity/EntityTypedDataDefinitionTest.php
@@ -151,6 +151,7 @@ class EntityTypedDataDefinitionTest extends KernelTestBase {
 
     $entity_type = $this->prophesize(EntityTypeInterface::class);
     $entity_type->entityClassImplements(ConfigEntityInterface::class)->willReturn(FALSE);
+    $entity_type->getKey('bundle')->willReturn(FALSE);
     $entity_type->getLabel()->willReturn($this->randomString());
     $entity_type->getConstraints()->willReturn([]);
     $entity_type->isInternal()->willReturn($internal);

--- a/core/tests/Drupal/KernelTests/Core/Extension/ModuleInstallerTest.php
+++ b/core/tests/Drupal/KernelTests/Core/Extension/ModuleInstallerTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\KernelTests\Core\Extension;
 
 use Drupal\Core\Database\Database;
+use Drupal\Core\Extension\MissingDependencyException;
 use Drupal\KernelTests\KernelTestBase;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
@@ -92,6 +93,62 @@ class ModuleInstallerTest extends KernelTestBase {
     \Drupal::state()->set('module_test_install:rebuild_container', TRUE);
     $module_installer = $this->container->get('module_installer');
     $this->assertTrue($module_installer->install(['module_test']));
+  }
+
+  /**
+   * Tests install with a module with an invalid core version constraint.
+   *
+   * @dataProvider providerTestInvalidCoreInstall
+   * @covers ::install
+   */
+  public function testInvalidCoreInstall($module_name, $install_dependencies) {
+    $this->expectException(MissingDependencyException::class);
+    $this->expectExceptionMessage("Unable to install modules: module '$module_name' is incompatible with this version of Drupal core.");
+    $this->container->get('module_installer')->install([$module_name], $install_dependencies);
+  }
+
+  /**
+   * Dataprovider for testInvalidCoreInstall().
+   */
+  public function providerTestInvalidCoreInstall() {
+    return [
+      'no dependencies system_incompatible_core_version_test_1x' => [
+        'system_incompatible_core_version_test_1x',
+        FALSE,
+      ],
+      'install_dependencies system_incompatible_core_version_test_1x' => [
+        'system_incompatible_core_version_test_1x',
+        TRUE,
+      ],
+      'no dependencies system_core_incompatible_semver_test' => [
+        'system_core_incompatible_semver_test',
+        FALSE,
+      ],
+      'install_dependencies system_core_incompatible_semver_test' => [
+        'system_core_incompatible_semver_test',
+        TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * Tests install with a dependency with an invalid core version constraint.
+   *
+   * @covers ::install
+   */
+  public function testDependencyInvalidCoreInstall() {
+    $this->expectException(MissingDependencyException::class);
+    $this->expectExceptionMessage("Unable to install modules: module 'system_incompatible_core_version_dependencies_test'. Its dependency module 'system_incompatible_core_version_test' is incompatible with this version of Drupal core.");
+    $this->container->get('module_installer')->install(['system_incompatible_core_version_dependencies_test']);
+  }
+
+  /**
+   * Tests no dependencies install with a dependency with invalid core.
+   *
+   * @covers ::install
+   */
+  public function testDependencyInvalidCoreInstallNoDependencies() {
+    $this->assertTrue($this->container->get('module_installer')->install(['system_incompatible_core_version_dependencies_test'], FALSE));
   }
 
 }

--- a/core/tests/Drupal/Tests/Core/Extension/InfoParserUnitTest.php
+++ b/core/tests/Drupal/Tests/Core/Extension/InfoParserUnitTest.php
@@ -3,6 +3,7 @@
 namespace Drupal\Tests\Core\Extension;
 
 use Drupal\Core\Extension\InfoParser;
+use Drupal\Core\Extension\InfoParserException;
 use Drupal\Tests\UnitTestCase;
 use org\bovigo\vfs\vfsStream;
 
@@ -96,8 +97,210 @@ MISSINGKEYS;
       ],
     ]);
     $filename = vfsStream::url('modules/fixtures/missing_keys.info.txt');
-    $this->setExpectedException('\Drupal\Core\Extension\InfoParserException', 'Missing required keys (type, core, name) in vfs://modules/fixtures/missing_keys.info.txt');
+    $this->expectException('\Drupal\Core\Extension\InfoParserException');
+    $this->expectExceptionMessage('Missing required keys (type, name) in vfs://modules/fixtures/missing_keys.info.txt');
     $this->infoParser->parse($filename);
+  }
+
+  /**
+   * Tests that missing 'core' and 'core_version_requirement' keys are detected.
+   *
+   * @covers ::parse
+   */
+  public function testMissingCoreCoreVersionRequirement() {
+    $missing_core_and_core_version_requirement = <<<MISSING_CORE_AND_CORE_VERSION_REQUIREMENT
+# info.yml for testing core and core_version_requirement.
+package: Core
+version: VERSION
+type: module
+name: Skynet
+dependencies:
+  - self_awareness
+MISSING_CORE_AND_CORE_VERSION_REQUIREMENT;
+
+    vfsStream::setup('modules');
+    vfsStream::create([
+      'fixtures' => [
+        'missing_core_and_core_version_requirement.info.txt' => $missing_core_and_core_version_requirement,
+        'missing_core_and_core_version_requirement-duplicate.info.txt' => $missing_core_and_core_version_requirement,
+      ],
+    ]);
+    $exception_message = "The 'core' or the 'core_version_requirement' key must be present in vfs://modules/fixtures/missing_core_and_core_version_requirement";
+    // Set the expected exception for the 2nd call to parse().
+    $this->expectException('\Drupal\Core\Extension\InfoParserException');
+    $this->expectExceptionMessage("$exception_message-duplicate.info.txt");
+
+    try {
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/missing_core_and_core_version_requirement.info.txt'));
+    }
+    catch (InfoParserException $exception) {
+      $this->assertSame("$exception_message.info.txt", $exception->getMessage());
+
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/missing_core_and_core_version_requirement-duplicate.info.txt'));
+    }
+  }
+
+  /**
+   * Tests that 'core_version_requirement: ^8.8' is valid with no 'core' key.
+   *
+   * @covers ::parse
+   */
+  public function testCoreVersionRequirement88() {
+    $core_version_requirement = <<<BOTH_CORE_VERSION_REQUIREMENT
+# info.yml for testing core and core_version_requirement keys.
+package: Core
+core_version_requirement: ^8.8
+version: VERSION
+type: module
+name: Module for That
+dependencies:
+  - field
+BOTH_CORE_VERSION_REQUIREMENT;
+
+    vfsStream::setup('modules');
+    foreach (['1', '2'] as $file_delta) {
+      $filename = "core_version_requirement-$file_delta.info.txt";
+      vfsStream::create([
+        'fixtures' => [
+          $filename => $core_version_requirement,
+        ],
+      ]);
+      $info_values = $this->infoParser->parse(vfsStream::url("modules/fixtures/$filename"));
+      $this->assertSame($info_values['core_version_requirement'], '^8.8', "Expected core_version_requirement for file: $filename");
+    }
+  }
+
+  /**
+   * Tests that 'core_version_requirement: ^8.8' is invalid with a 'core' key.
+   *
+   * @covers ::parse
+   */
+  public function testCoreCoreVersionRequirement88() {
+    $core_and_core_version_requirement_88 = <<<BOTH_CORE_CORE_VERSION_REQUIREMENT_88
+# info.yml for testing core and core_version_requirement keys.
+package: Core
+core: 8.x
+core_version_requirement: ^8.8
+version: VERSION
+type: module
+name: Form auto submitter
+dependencies:
+  - field
+BOTH_CORE_CORE_VERSION_REQUIREMENT_88;
+
+    vfsStream::setup('modules');
+    vfsStream::create([
+      'fixtures' => [
+        'core_and_core_version_requirement_88.info.txt' => $core_and_core_version_requirement_88,
+        'core_and_core_version_requirement_88-duplicate.info.txt' => $core_and_core_version_requirement_88,
+      ],
+    ]);
+    $exception_message = "The 'core_version_requirement' constraint (^8.8) requires the 'core' key not be set in vfs://modules/fixtures/core_and_core_version_requirement_88";
+    // Set the expected exception for the 2nd call to parse().
+    $this->expectException('\Drupal\Core\Extension\InfoParserException');
+    $this->expectExceptionMessage("$exception_message-duplicate.info.txt");
+    try {
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/core_and_core_version_requirement_88.info.txt'));
+    }
+    catch (InfoParserException $exception) {
+      $this->assertSame("$exception_message.info.txt", $exception->getMessage());
+
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/core_and_core_version_requirement_88-duplicate.info.txt'));
+    }
+  }
+
+  /**
+   * Tests a invalid 'core' key.
+   *
+   * @covers ::parse
+   */
+  public function testInvalidCore() {
+    $invalid_core = <<<INVALID_CORE
+# info.yml for testing invalid core key.
+package: Core
+core: ^8
+version: VERSION
+type: module
+name: Llama or Alpaca
+description: Tells whether an image is of a Llama or Alpaca
+dependencies:
+  - llama_detector
+  - alpaca_detector
+INVALID_CORE;
+
+    vfsStream::setup('modules');
+    vfsStream::create([
+      'fixtures' => [
+        'invalid_core.info.txt' => $invalid_core,
+        'invalid_core-duplicate.info.txt' => $invalid_core,
+      ],
+    ]);
+    $exception_message = "Invalid 'core' value \"^8\" in vfs://modules/fixtures/invalid_core";
+    // Set the expected exception for the 2nd call to parse().
+    $this->expectException('\Drupal\Core\Extension\InfoParserException');
+    $this->expectExceptionMessage("$exception_message-duplicate.info.txt");
+
+    try {
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/invalid_core.info.txt'));
+    }
+    catch (InfoParserException $exception) {
+      $this->assertSame("$exception_message.info.txt", $exception->getMessage());
+
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/invalid_core-duplicate.info.txt'));
+    }
+  }
+
+  /**
+   * Tests a invalid 'core_version_requirement'.
+   *
+   * @covers ::parse
+   *
+   * @dataProvider providerCoreVersionRequirementInvalid
+   */
+  public function testCoreVersionRequirementInvalid($test_case, $constraint) {
+    $invalid_core_version_requirement = <<<INVALID_CORE_VERSION_REQUIREMENT
+# info.yml for core_version_requirement validation.
+name: Gracie Evaluator
+description: 'Determines if Gracie is a "Good Dog". The answer is always "Yes".'
+package: Core
+type: module
+version: VERSION
+core_version_requirement: '$constraint'
+dependencies:
+  - goodness_api
+INVALID_CORE_VERSION_REQUIREMENT;
+
+    vfsStream::setup('modules');
+    vfsStream::create([
+      'fixtures' => [
+        "invalid_core_version_requirement-$test_case.info.txt" => $invalid_core_version_requirement,
+        "invalid_core_version_requirement-$test_case-duplicate.info.txt" => $invalid_core_version_requirement,
+      ],
+    ]);
+    $exception_message = "The 'core_version_requirement' can not be used to specify compatibility for a specific version before 8.7.7 in vfs://modules/fixtures/invalid_core_version_requirement-$test_case";
+    // Set the expected exception for the 2nd call to parse().
+    $this->expectException('\Drupal\Core\Extension\InfoParserException');
+    $this->expectExceptionMessage("$exception_message-duplicate.info.txt");
+    try {
+      $this->infoParser->parse(vfsStream::url("modules/fixtures/invalid_core_version_requirement-$test_case.info.txt"));
+    }
+    catch (InfoParserException $exception) {
+      $this->assertSame("$exception_message.info.txt", $exception->getMessage());
+
+      $this->infoParser->parse(vfsStream::url("modules/fixtures/invalid_core_version_requirement-$test_case-duplicate.info.txt"));
+    }
+  }
+
+  /**
+   * Dataprovider for testCoreVersionRequirementInvalid().
+   */
+  public function providerCoreVersionRequirementInvalid() {
+    return [
+      '8.0.0-alpha2' => ['alpha2', '8.0.0-alpha2'],
+      '8.6.0-rc1' => ['rc1', '8.6.0-rc1'],
+      '^8.7' => ['8_7', '^8.7'],
+      '>8.6.3' => ['gt8_6_3', '>8.6.3'],
+    ];
   }
 
   /**
@@ -121,11 +324,20 @@ MISSINGKEY;
     vfsStream::create([
       'fixtures' => [
         'missing_key.info.txt' => $missing_key,
+        'missing_key-duplicate.info.txt' => $missing_key,
       ],
     ]);
-    $filename = vfsStream::url('modules/fixtures/missing_key.info.txt');
-    $this->setExpectedException('\Drupal\Core\Extension\InfoParserException', 'Missing required keys (type) in vfs://modules/fixtures/missing_key.info.txt');
-    $this->infoParser->parse($filename);
+    try {
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/missing_key.info.txt'));
+    }
+    catch (InfoParserException $exception) {
+      $this->assertSame('Missing required keys (type) in vfs://modules/fixtures/missing_key.info.txt', $exception->getMessage());
+
+      $this->expectException('\Drupal\Core\Extension\InfoParserException');
+      $this->expectExceptionMessage('Missing required keys (type) in vfs://modules/fixtures/missing_key-duplicate.info.txt');
+      $this->infoParser->parse(vfsStream::url('modules/fixtures/missing_key-duplicate.info.txt'));
+    }
+
   }
 
   /**
@@ -145,15 +357,128 @@ double_colon: dummyClassName::method
 COMMONTEST;
 
     vfsStream::setup('modules');
+
+    foreach (['1', '2'] as $file_delta) {
+      $filename = "common_test-$file_delta.info.txt";
+      vfsStream::create([
+        'fixtures' => [
+          $filename => $common,
+        ],
+      ]);
+      $info_values = $this->infoParser->parse(vfsStream::url("modules/fixtures/$filename"));
+      $this->assertEquals($info_values['simple_string'], 'A simple string', 'Simple string value was parsed correctly.');
+      $this->assertEquals($info_values['version'], \Drupal::VERSION, 'Constant value was parsed correctly.');
+      $this->assertEquals($info_values['double_colon'], 'dummyClassName::method', 'Value containing double-colon was parsed correctly.');
+      $this->assertSame('8.x', $info_values['core']);
+      $this->assertFalse(isset($info_values['core_version_requirement']));
+      $this->assertFalse($info_values['core_incompatible']);
+    }
+  }
+
+  /**
+   * @covers ::parse
+   *
+   * @dataProvider providerCoreIncompatibility
+   */
+  public function testCoreIncompatibility($test_case, $constraint, $expected) {
+    $core_incompatibility = <<<CORE_INCOMPATIBILITY
+core_version_requirement: $constraint
+name: common_test
+type: module
+description: 'testing info file parsing'
+simple_string: 'A simple string'
+version: "VERSION"
+double_colon: dummyClassName::method
+CORE_INCOMPATIBILITY;
+
+    vfsStream::setup('modules');
+    foreach (['1', '2'] as $file_delta) {
+      $filename = "core_incompatible-$test_case-$file_delta.info.txt";
+      vfsStream::create([
+        'fixtures' => [
+          $filename => $core_incompatibility,
+        ],
+      ]);
+      $info_values = $this->infoParser->parse(vfsStream::url("modules/fixtures/$filename"));
+      $this->assertSame($expected, $info_values['core_incompatible'], "core_incompatible correct in file: $filename");
+    }
+  }
+
+  /**
+   * Dataprovider for testCoreIncompatibility().
+   */
+  public function providerCoreIncompatibility() {
+    list($major, $minor) = explode('.', \Drupal::VERSION);
+
+    $next_minor = $minor + 1;
+    $next_major = $major + 1;
+    return [
+      'next_minor' => [
+        'next_minor',
+        "^$major.$next_minor",
+        TRUE,
+      ],
+      'current_major_next_major' => [
+        'current_major_next_major',
+        "^$major || ^$next_major",
+        FALSE,
+      ],
+      'previous_major_next_major' => [
+        'previous_major_next_major',
+        "^1 || ^$next_major",
+        TRUE,
+      ],
+    ];
+  }
+
+  /**
+   * Test a profile info file with the 'core_version_requirement' key.
+   */
+  public function testInvalidProfile() {
+    $profile = <<<PROFILE_TEST
+core: 8.x
+core_version_requirement: ^8
+name: The Perfect Profile
+type: profile
+description: 'This profile makes Drupal perfect. You should have no complaints.'
+PROFILE_TEST;
+
+    vfsStream::setup('profiles');
     vfsStream::create([
       'fixtures' => [
-        'common_test.info.txt' => $common,
+        'invalid_profile.info.txt' => $profile,
       ],
     ]);
-    $info_values = $this->infoParser->parse(vfsStream::url('modules/fixtures/common_test.info.txt'));
-    $this->assertEquals($info_values['simple_string'], 'A simple string', 'Simple string value was parsed correctly.');
-    $this->assertEquals($info_values['version'], \Drupal::VERSION, 'Constant value was parsed correctly.');
-    $this->assertEquals($info_values['double_colon'], 'dummyClassName::method', 'Value containing double-colon was parsed correctly.');
+    $this->expectException('\Drupal\Core\Extension\InfoParserException');
+    $this->expectExceptionMessage("The 'core_version_requirement' key is not supported in profiles in vfs://profiles/fixtures/invalid_profile.info.txt");
+    $this->infoParser->parse(vfsStream::url('profiles/fixtures/invalid_profile.info.txt'));
+  }
+
+  /**
+   * Tests the exception for an unparsable 'core_version_requirement' value.
+   *
+   * @covers ::parse
+   */
+  public function testUnparsableCoreVersionRequirement() {
+    $unparsable_core_version_requirement = <<<UNPARSABLE_CORE_VERSION_REQUIREMENT
+# info.yml for testing invalid core_version_requirement value.
+name: Not this module
+description: 'Not the module you are looking for.'
+package: Core
+type: module
+version: VERSION
+core_version_requirement: not-this-version
+UNPARSABLE_CORE_VERSION_REQUIREMENT;
+
+    vfsStream::setup('modules');
+    vfsStream::create([
+      'fixtures' => [
+        'unparsable_core_version_requirement.info.txt' => $unparsable_core_version_requirement,
+      ],
+    ]);
+    $this->expectException(\UnexpectedValueException::class);
+    $this->expectExceptionMessage('Could not parse version constraint not-this-version: Invalid version string "not-this-version"');
+    $this->infoParser->parse(vfsStream::url('modules/fixtures/unparsable_core_version_requirement.info.txt'));
   }
 
 }

--- a/core/tests/Drupal/Tests/Listeners/DeprecationListenerTrait.php
+++ b/core/tests/Drupal/Tests/Listeners/DeprecationListenerTrait.php
@@ -144,6 +144,9 @@ trait DeprecationListenerTrait {
       // higher
       'The "Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory" class is deprecated since symfony/psr-http-message-bridge 1.2, use PsrHttpFactory instead.',
       'The "psr7.http_message_factory" service relies on the deprecated "Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory" class. It should either be deprecated or its implementation upgraded.',
+      // This deprecation comes from behat/mink-browserkit-driver when updating
+      // symfony/browser-kit to 4.3+.
+      'The "Symfony\Component\BrowserKit\Response::getStatus()" method is deprecated since Symfony 4.3, use getStatusCode() instead.',
     ];
   }
 

--- a/core/tests/Drupal/Tests/WebAssert.php
+++ b/core/tests/Drupal/Tests/WebAssert.php
@@ -492,6 +492,35 @@ class WebAssert extends MinkWebAssert {
   }
 
   /**
+   * Checks that a given form field element is enabled.
+   *
+   * @param string $field
+   *   One of id|name|label|value for the field.
+   * @param \Behat\Mink\Element\TraversableElement $container
+   *   (optional) The document to check against. Defaults to the current page.
+   *
+   * @return \Behat\Mink\Element\NodeElement
+   *   The matching element.
+   *
+   * @throws \Behat\Mink\Exception\ElementNotFoundException
+   * @throws \Behat\Mink\Exception\ExpectationException
+   */
+  public function fieldEnabled($field, TraversableElement $container = NULL) {
+    $container = $container ?: $this->session->getPage();
+    $node = $container->findField($field);
+
+    if ($node === NULL) {
+      throw new ElementNotFoundException($this->session->getDriver(), 'field', 'id|name|label|value', $field);
+    }
+
+    if ($node->hasAttribute('disabled')) {
+      throw new ExpectationException("Field $field is not enabled", $this->session->getDriver());
+    }
+
+    return $node;
+  }
+
+  /**
    * Checks that specific hidden field exists.
    *
    * @param string $field


### PR DESCRIPTION
Update from Drupal 8.7.6 to Drupal 8.7.7.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-8), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 8 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
    - git fetch drops-8
    - git merge drops-8/update-8.7.7
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
