### PR TITLE
[CORE-1355] Enforce HTTPS by default.

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -4,3 +4,6 @@
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
 php_version: 7.3
+
+# See https://pantheon.io/docs/pantheon-yml/#enforce-https--hsts for valid values.
+enforce_https: transitional


### PR DESCRIPTION
Enforce HTTPS. For more info see https://pantheon.io/blog/pantheon-now-enforces-https-default-plus-really-simple-hsts

Create your own test site to verify:

  - Create a new Drupal 8 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
    - git fetch drops-8
    - git merge drops-8/https-by-default
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
