### PR TITLE
Update to Drupal 8.7.9. For more information, see https://www.drupal.org/project/drupal/releases/8.7.9

### DIFF
--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.7.8';
+  const VERSION = '8.7.9';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Entity/EntityTypeListener.php
+++ b/core/lib/Drupal/Core/Entity/EntityTypeListener.php
@@ -71,12 +71,13 @@ class EntityTypeListener implements EntityTypeListenerInterface {
       $storage->onEntityTypeCreate($entity_type);
     }
 
-    $this->eventDispatcher->dispatch(EntityTypeEvents::CREATE, new EntityTypeEvent($entity_type));
-
     $this->entityLastInstalledSchemaRepository->setLastInstalledDefinition($entity_type);
     if ($entity_type->entityClassImplements(FieldableEntityInterface::class)) {
       $this->entityLastInstalledSchemaRepository->setLastInstalledFieldStorageDefinitions($entity_type_id, $this->entityFieldManager->getFieldStorageDefinitions($entity_type_id));
     }
+
+    $this->eventDispatcher->dispatch(EntityTypeEvents::CREATE, new EntityTypeEvent($entity_type));
+    $this->clearCachedDefinitions();
   }
 
   /**
@@ -94,9 +95,10 @@ class EntityTypeListener implements EntityTypeListenerInterface {
       $storage->onEntityTypeUpdate($entity_type, $original);
     }
 
-    $this->eventDispatcher->dispatch(EntityTypeEvents::UPDATE, new EntityTypeEvent($entity_type, $original));
-
     $this->entityLastInstalledSchemaRepository->setLastInstalledDefinition($entity_type);
+
+    $this->eventDispatcher->dispatch(EntityTypeEvents::UPDATE, new EntityTypeEvent($entity_type, $original));
+    $this->clearCachedDefinitions();
   }
 
   /**
@@ -116,9 +118,10 @@ class EntityTypeListener implements EntityTypeListenerInterface {
       $storage->onEntityTypeDelete($entity_type);
     }
 
-    $this->eventDispatcher->dispatch(EntityTypeEvents::DELETE, new EntityTypeEvent($entity_type));
-
     $this->entityLastInstalledSchemaRepository->deleteLastInstalledDefinition($entity_type_id);
+
+    $this->eventDispatcher->dispatch(EntityTypeEvents::DELETE, new EntityTypeEvent($entity_type));
+    $this->clearCachedDefinitions();
   }
 
   /**
@@ -135,13 +138,22 @@ class EntityTypeListener implements EntityTypeListenerInterface {
     }
 
     if ($sandbox === NULL || (isset($sandbox['#finished']) && $sandbox['#finished'] == 1)) {
-      $this->eventDispatcher->dispatch(EntityTypeEvents::UPDATE, new EntityTypeEvent($entity_type, $original));
-
       $this->entityLastInstalledSchemaRepository->setLastInstalledDefinition($entity_type);
       if ($entity_type->entityClassImplements(FieldableEntityInterface::class)) {
         $this->entityLastInstalledSchemaRepository->setLastInstalledFieldStorageDefinitions($entity_type_id, $field_storage_definitions);
       }
+
+      $this->eventDispatcher->dispatch(EntityTypeEvents::UPDATE, new EntityTypeEvent($entity_type, $original));
+      $this->clearCachedDefinitions();
     }
+  }
+
+  /**
+   * Clears necessary caches to apply entity/field definition updates.
+   */
+  protected function clearCachedDefinitions() {
+    $this->entityTypeManager->clearCachedDefinitions();
+    $this->entityFieldManager->clearCachedFieldDefinitions();
   }
 
 }

--- a/core/lib/Drupal/Core/Field/FieldStorageDefinitionListener.php
+++ b/core/lib/Drupal/Core/Field/FieldStorageDefinitionListener.php
@@ -85,9 +85,9 @@ class FieldStorageDefinitionListener implements FieldStorageDefinitionListenerIn
       $storage->onFieldStorageDefinitionCreate($storage_definition);
     }
 
-    $this->eventDispatcher->dispatch(FieldStorageDefinitionEvents::CREATE, new FieldStorageDefinitionEvent($storage_definition));
-
     $this->entityLastInstalledSchemaRepository->setLastInstalledFieldStorageDefinition($storage_definition);
+
+    $this->eventDispatcher->dispatch(FieldStorageDefinitionEvents::CREATE, new FieldStorageDefinitionEvent($storage_definition));
     $this->entityFieldManager->clearCachedFieldDefinitions();
   }
 
@@ -104,9 +104,9 @@ class FieldStorageDefinitionListener implements FieldStorageDefinitionListenerIn
       $storage->onFieldStorageDefinitionUpdate($storage_definition, $original);
     }
 
-    $this->eventDispatcher->dispatch(FieldStorageDefinitionEvents::UPDATE, new FieldStorageDefinitionEvent($storage_definition, $original));
-
     $this->entityLastInstalledSchemaRepository->setLastInstalledFieldStorageDefinition($storage_definition);
+
+    $this->eventDispatcher->dispatch(FieldStorageDefinitionEvents::UPDATE, new FieldStorageDefinitionEvent($storage_definition, $original));
     $this->entityFieldManager->clearCachedFieldDefinitions();
   }
 
@@ -133,9 +133,9 @@ class FieldStorageDefinitionListener implements FieldStorageDefinitionListenerIn
       $storage->onFieldStorageDefinitionDelete($storage_definition);
     }
 
-    $this->eventDispatcher->dispatch(FieldStorageDefinitionEvents::DELETE, new FieldStorageDefinitionEvent($storage_definition));
-
     $this->entityLastInstalledSchemaRepository->deleteLastInstalledFieldStorageDefinition($storage_definition);
+
+    $this->eventDispatcher->dispatch(FieldStorageDefinitionEvents::DELETE, new FieldStorageDefinitionEvent($storage_definition));
     $this->entityFieldManager->clearCachedFieldDefinitions();
   }
 

--- a/core/lib/Drupal/Core/Menu/Form/MenuLinkDefaultForm.php
+++ b/core/lib/Drupal/Core/Menu/Form/MenuLinkDefaultForm.php
@@ -50,13 +50,6 @@ class MenuLinkDefaultForm implements MenuLinkFormInterface, ContainerInjectionIn
   protected $moduleHandler;
 
   /**
-   * The module data from system_get_info().
-   *
-   * @var array
-   */
-  protected $moduleData;
-
-  /**
    * Constructs a new \Drupal\Core\Menu\Form\MenuLinkDefaultForm.
    *
    * @param \Drupal\Core\Menu\MenuLinkManagerInterface $menu_link_manager

--- a/core/lib/Drupal/Core/TypedData/Validation/RecursiveContextualValidator.php
+++ b/core/lib/Drupal/Core/TypedData/Validation/RecursiveContextualValidator.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Core\TypedData\Validation;
 
+use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
 use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\Core\TypedData\ListInterface;
 use Drupal\Core\TypedData\TypedDataInterface;
@@ -136,6 +137,7 @@ class RecursiveContextualValidator implements ContextualValidatorInterface {
     // constraint validators, such that they do not have to care about Typed
     // Data.
     $value = $typed_data_manager->getCanonicalRepresentation($data);
+    $constraints_given = isset($constraints);
     $this->context->setNode($value, $data, $metadata, $property_path);
 
     if (isset($constraints) || !$this->context->isGroupValidated($cache_key, Constraint::DEFAULT_GROUP)) {
@@ -148,7 +150,10 @@ class RecursiveContextualValidator implements ContextualValidatorInterface {
 
     // If the data is a list or complex data, validate the contained list items
     // or properties. However, do not recurse if the data is empty.
-    if (($data instanceof ListInterface || $data instanceof ComplexDataInterface) && !$data->isEmpty()) {
+    // Next, we do not recurse if given constraints are validated against an
+    // entity, since we should determine whether the entity matches the
+    // constraints and not whether the entity validates.
+    if (($data instanceof ListInterface || $data instanceof ComplexDataInterface) && !$data->isEmpty() && !($data instanceof EntityAdapter && $constraints_given)) {
       foreach ($data as $name => $property) {
         $this->validateNode($property);
       }

--- a/core/modules/image/image.module
+++ b/core/modules/image/image.module
@@ -275,7 +275,6 @@ function image_style_options($include_empty = TRUE) {
  *   - width: The width of the image.
  *   - height: The height of the image.
  *   - style_name: The name of the image style to be applied.
- *   - attributes: Additional attributes to apply to the image.
  *   - uri: URI of the source image before styling.
  *   - alt: The alternative text for text-based browsers. HTML 4 and XHTML 1.0
  *     always require an alt attribute. The HTML 5 draft allows the alt
@@ -289,7 +288,8 @@ function image_style_options($include_empty = TRUE) {
  *     - http://dev.w3.org/html5/spec/Overview.html#alt
  *   - title: The title text is displayed when the image is hovered in some
  *     popular browsers.
- *   - attributes: Associative array of attributes to be placed in the img tag.
+ *   - attributes: Associative array of additional attributes to be placed in
+ *     the img tag.
  */
 function template_preprocess_image_style(&$variables) {
   $style = ImageStyle::load($variables['style_name']);

--- a/core/modules/system/tests/modules/entity_test/entity_test.services.yml
+++ b/core/modules/system/tests/modules/entity_test/entity_test.services.yml
@@ -1,7 +1,7 @@
 services:
   entity_test.definition.subscriber:
     class: Drupal\entity_test\EntityTestDefinitionSubscriber
-    arguments: ['@state']
+    arguments: ['@state', '@entity.last_installed_schema.repository', '@entity_type.manager', '@entity_field.manager']
     tags:
       - { name: event_subscriber }
   cache_context.entity_test_view_grants:

--- a/core/modules/system/tests/modules/entity_test/src/EntityTestDefinitionSubscriber.php
+++ b/core/modules/system/tests/modules/entity_test/src/EntityTestDefinitionSubscriber.php
@@ -2,10 +2,13 @@
 
 namespace Drupal\entity_test;
 
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Entity\EntityLastInstalledSchemaRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeEvents;
 use Drupal\Core\Entity\EntityTypeEventSubscriberTrait;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Entity\EntityTypeListenerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\FieldStorageDefinitionEvents;
 use Drupal\Core\Field\FieldStorageDefinitionEventSubscriberTrait;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
@@ -29,6 +32,27 @@ class EntityTestDefinitionSubscriber implements EventSubscriberInterface, Entity
   protected $state;
 
   /**
+   * The last installed schema repository.
+   *
+   * @var \Drupal\Core\Entity\EntityLastInstalledSchemaRepositoryInterface
+   */
+  protected $entityLastInstalledSchemaRepository;
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The entity field manager.
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface
+   */
+  protected $entityFieldManager;
+
+  /**
    * Flag determining whether events should be tracked.
    *
    * @var bool
@@ -36,10 +60,20 @@ class EntityTestDefinitionSubscriber implements EventSubscriberInterface, Entity
   protected $trackEvents = FALSE;
 
   /**
+   * Determines whether the live definitions should be updated.
+   *
+   * @var bool
+   */
+  protected $updateLiveDefinitions = FALSE;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(StateInterface $state) {
+  public function __construct(StateInterface $state, EntityLastInstalledSchemaRepositoryInterface $entity_last_installed_schema_repository, EntityTypeManagerInterface $entity_type_manager, EntityFieldManagerInterface $entity_field_manager) {
     $this->state = $state;
+    $this->entityLastInstalledSchemaRepository = $entity_last_installed_schema_repository;
+    $this->entityTypeManager = $entity_type_manager;
+    $this->entityFieldManager = $entity_field_manager;
   }
 
   /**
@@ -53,14 +87,38 @@ class EntityTestDefinitionSubscriber implements EventSubscriberInterface, Entity
    * {@inheritdoc}
    */
   public function onEntityTypeCreate(EntityTypeInterface $entity_type) {
+    if ($this->entityLastInstalledSchemaRepository->getLastInstalledDefinition($entity_type->id())) {
+      $this->storeDefinitionUpdate(EntityTypeEvents::CREATE);
+    }
     $this->storeEvent(EntityTypeEvents::CREATE);
+
+    // Retrieve the live entity type definition in order to warm the static
+    // cache and then insert the new entity type definition, so we can test that
+    // the cache doesn't get stale after the event has fired.
+    if ($this->updateLiveDefinitions) {
+      $this->entityTypeManager->getDefinition($entity_type->id());
+      $this->state->set('entity_test_rev.entity_type', $entity_type);
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function onEntityTypeUpdate(EntityTypeInterface $entity_type, EntityTypeInterface $original) {
+    $last_installed_definition = $this->entityLastInstalledSchemaRepository->getLastInstalledDefinition($entity_type->id());
+    if ((string) $last_installed_definition->getLabel() === 'Updated entity test rev') {
+      $this->storeDefinitionUpdate(EntityTypeEvents::UPDATE);
+    }
+
     $this->storeEvent(EntityTypeEvents::UPDATE);
+
+    // Retrieve the live entity type definition in order to warm the static
+    // cache and then insert the new entity type definition, so we can test that
+    // the cache doesn't get stale after the event has fired.
+    if ($this->updateLiveDefinitions) {
+      $this->entityTypeManager->getDefinition($entity_type->id());
+      $this->state->set('entity_test_rev.entity_type', $entity_type);
+    }
   }
 
   /**
@@ -74,28 +132,73 @@ class EntityTestDefinitionSubscriber implements EventSubscriberInterface, Entity
    * {@inheritdoc}
    */
   public function onEntityTypeDelete(EntityTypeInterface $entity_type) {
+    if (!$this->entityLastInstalledSchemaRepository->getLastInstalledDefinition($entity_type->id())) {
+      $this->storeDefinitionUpdate(EntityTypeEvents::DELETE);
+    }
     $this->storeEvent(EntityTypeEvents::DELETE);
+
+    // Retrieve the live entity type definition in order to warm the static
+    // cache and then delete the new entity type definition, so we can test that
+    // the cache doesn't get stale after the event has fired.
+    if ($this->updateLiveDefinitions) {
+      $this->entityTypeManager->getDefinition($entity_type->id());
+      $this->state->set('entity_test_rev.entity_type', '');
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function onFieldStorageDefinitionCreate(FieldStorageDefinitionInterface $storage_definition) {
+    if (isset($this->entityLastInstalledSchemaRepository->getLastInstalledFieldStorageDefinitions($storage_definition->getTargetEntityTypeId())[$storage_definition->getName()])) {
+      $this->storeDefinitionUpdate(FieldStorageDefinitionEvents::CREATE);
+    }
     $this->storeEvent(FieldStorageDefinitionEvents::CREATE);
+
+    // Retrieve the live field storage definitions in order to warm the static
+    // cache and then insert the new storage definition, so we can test that the
+    // cache doesn't get stale after the event has fired.
+    if ($this->updateLiveDefinitions) {
+      $this->entityFieldManager->getFieldStorageDefinitions($storage_definition->getTargetEntityTypeId());
+      $this->state->set('entity_test_rev.additional_base_field_definitions', [$storage_definition->getName() => $storage_definition]);
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function onFieldStorageDefinitionUpdate(FieldStorageDefinitionInterface $storage_definition, FieldStorageDefinitionInterface $original) {
+    $last_installed_definition = $this->entityLastInstalledSchemaRepository->getLastInstalledFieldStorageDefinitions($storage_definition->getTargetEntityTypeId())[$storage_definition->getName()];
+    if ((string) $last_installed_definition->getLabel() === 'Updated field storage test') {
+      $this->storeDefinitionUpdate(FieldStorageDefinitionEvents::UPDATE);
+    }
     $this->storeEvent(FieldStorageDefinitionEvents::UPDATE);
+
+    // Retrieve the live field storage definitions in order to warm the static
+    // cache and then insert the new storage definition, so we can test that the
+    // cache doesn't get stale after the event has fired.
+    if ($this->updateLiveDefinitions) {
+      $this->entityFieldManager->getFieldStorageDefinitions($storage_definition->getTargetEntityTypeId());
+      $this->state->set('entity_test_rev.additional_base_field_definitions', [$storage_definition->getName() => $storage_definition]);
+    }
   }
 
   /**
    * {@inheritdoc}
    */
   public function onFieldStorageDefinitionDelete(FieldStorageDefinitionInterface $storage_definition) {
+    if (!isset($this->entityLastInstalledSchemaRepository->getLastInstalledFieldStorageDefinitions($storage_definition->getTargetEntityTypeId())[$storage_definition->getName()])) {
+      $this->storeDefinitionUpdate(FieldStorageDefinitionEvents::DELETE);
+    }
     $this->storeEvent(FieldStorageDefinitionEvents::DELETE);
+
+    // Retrieve the live field storage definitions in order to warm the static
+    // cache and then remove the new storage definition, so we can test that the
+    // cache doesn't get stale after the event has fired.
+    if ($this->updateLiveDefinitions) {
+      $this->entityFieldManager->getFieldStorageDefinitions($storage_definition->getTargetEntityTypeId());
+      $this->state->set('entity_test_rev.additional_base_field_definitions', []);
+    }
   }
 
   /**
@@ -103,6 +206,13 @@ class EntityTestDefinitionSubscriber implements EventSubscriberInterface, Entity
    */
   public function enableEventTracking() {
     $this->trackEvents = TRUE;
+  }
+
+  /**
+   * Enables live definition updates.
+   */
+  public function enableLiveDefinitionUpdates() {
+    $this->updateLiveDefinitions = TRUE;
   }
 
   /**
@@ -127,6 +237,32 @@ class EntityTestDefinitionSubscriber implements EventSubscriberInterface, Entity
   protected function storeEvent($event_name) {
     if ($this->trackEvents) {
       $this->state->set($event_name, TRUE);
+    }
+  }
+
+  /**
+   * Checks whether the installed definitions were updated before the event.
+   *
+   * @param string $event_name
+   *   The event name.
+   *
+   * @return bool
+   *   TRUE if the last installed entity type of field storage definitions have
+   *   been updated before the event was fired, FALSE otherwise.
+   */
+  public function hasDefinitionBeenUpdated($event_name) {
+    return (bool) $this->state->get($event_name . '_updated_definition');
+  }
+
+  /**
+   * Stores the installed definition state for the specified event.
+   *
+   * @param string $event_name
+   *   The event name.
+   */
+  protected function storeDefinitionUpdate($event_name) {
+    if ($this->trackEvents) {
+      $this->state->set($event_name . '_updated_definition', TRUE);
     }
   }
 

--- a/core/modules/system/tests/modules/entity_test_update/entity_test_update.services.yml
+++ b/core/modules/system/tests/modules/entity_test_update/entity_test_update.services.yml
@@ -1,0 +1,6 @@
+services:
+  entity_test_update.entity_schema_listener:
+    class: Drupal\entity_test_update\EventSubscriber\EntitySchemaSubscriber
+    arguments: ['@entity.definition_update_manager', '@state']
+    tags:
+      - { name: 'event_subscriber' }

--- a/core/modules/system/tests/modules/entity_test_update/src/EventSubscriber/EntitySchemaSubscriber.php
+++ b/core/modules/system/tests/modules/entity_test_update/src/EventSubscriber/EntitySchemaSubscriber.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\entity_test_update\EventSubscriber;
+
+use Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface;
+use Drupal\Core\Entity\EntityTypeEventSubscriberTrait;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Entity\EntityTypeListenerInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Defines a class for listening to entity schema changes.
+ */
+class EntitySchemaSubscriber implements EntityTypeListenerInterface, EventSubscriberInterface {
+
+  use EntityTypeEventSubscriberTrait;
+
+  /**
+   * The entity definition update manager.
+   *
+   * @var \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface
+   */
+  protected $entityDefinitionUpdateManager;
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Constructs a new EntitySchemaSubscriber.
+   *
+   * @param \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface $entityDefinitionUpdateManager
+   *   The entity definition update manager.
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   */
+  public function __construct(EntityDefinitionUpdateManagerInterface $entityDefinitionUpdateManager, StateInterface $state) {
+    $this->entityDefinitionUpdateManager = $entityDefinitionUpdateManager;
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return static::getEntityTypeEvents();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function onEntityTypeUpdate(EntityTypeInterface $entity_type, EntityTypeInterface $original) {
+    // Only add the new base field when a test needs it.
+    if (!$this->state->get('entity_test_update.install_new_base_field_during_update', FALSE)) {
+      return;
+    }
+
+    // Add a new base field when the entity type is updated.
+    $definitions = $this->state->get('entity_test_update.additional_base_field_definitions', []);
+    $definitions['new_base_field'] = BaseFieldDefinition::create('string')
+      ->setName('new_base_field')
+      ->setLabel(new TranslatableMarkup('A new base field'));
+    $this->state->set('entity_test_update.additional_base_field_definitions', $definitions);
+
+    $this->entityDefinitionUpdateManager->installFieldStorageDefinition('new_base_field', 'entity_test_update', 'entity_test_update', $definitions['new_base_field']);
+  }
+
+}

--- a/core/modules/toolbar/src/Element/ToolbarItem.php
+++ b/core/modules/toolbar/src/Element/ToolbarItem.php
@@ -56,7 +56,6 @@ class ToolbarItem extends RenderElement {
       // Provide attributes necessary for trays.
       $attributes += [
         'data-toolbar-tray' => $id . '-tray',
-        'aria-owns' => $id . '-tray',
         'role' => 'button',
         'aria-pressed' => 'false',
       ];

--- a/core/modules/views/src/Plugin/views/field/RenderedEntity.php
+++ b/core/modules/views/src/Plugin/views/field/RenderedEntity.php
@@ -153,7 +153,7 @@ class RenderedEntity extends FieldPluginBase implements CacheableDependencyInter
       $build['#access'] = $access;
       if ($access->isAllowed()) {
         $view_builder = $this->entityTypeManager->getViewBuilder($this->getEntityTypeId());
-        $build += $view_builder->view($entity, $this->options['view_mode']);
+        $build += $view_builder->view($entity, $this->options['view_mode'], $entity->language()->getId());
       }
     }
     return $build;

--- a/core/modules/views/tests/modules/views_test_config/test_views/views.view.test_entity_field_renderered_entity.yml
+++ b/core/modules/views/tests/modules/views_test_config/test_views/views.view.test_entity_field_renderered_entity.yml
@@ -1,0 +1,211 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.default
+  module:
+    - node
+id: test_entity_field_renderered_entity
+label: test_entity_field_renderered_entity
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      defaults:
+        fields: false
+        pager: false
+        sorts: false
+      pager:
+        options:
+          offset: 0
+        type: none
+      row:
+        type: fields
+      sorts:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          plugin_id: standard
+          entity_type: node
+          entity_field: title
+      rendering_language: '***LANGUAGE_entity_translation***'
+      fields:
+        rendered_entity:
+          id: rendered_entity
+          table: node
+          field: rendered_entity
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          view_mode: default
+          entity_type: node
+          plugin_id: rendered_entity
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      rendering_language: '***LANGUAGE_entity_translation***'
+      path: test_entity_field_renderered_entity/entity_translation
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'
+  page_2:
+    display_plugin: page
+    id: page_2
+    display_title: Page
+    position: 2
+    display_options:
+      rendering_language: '***LANGUAGE_entity_default***'
+      path: test_entity_field_renderered_entity/entity_default
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'
+  page_3:
+    display_plugin: page
+    id: page_3
+    display_title: Page
+    position: 3
+    display_options:
+      rendering_language: '***LANGUAGE_site_default***'
+      path: test_entity_field_renderered_entity/site_default
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'
+  page_4:
+    display_plugin: page
+    id: page_4
+    display_title: Page
+    position: 4
+    display_options:
+      rendering_language: '***LANGUAGE_language_interface***'
+      path: test_entity_field_renderered_entity/language_interface
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'
+  page_5:
+    display_plugin: page
+    id: page_5
+    display_title: Page
+    position: 5
+    display_options:
+      rendering_language: en
+      path: test_entity_field_renderered_entity/en
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'
+  page_6:
+    display_plugin: page
+    id: page_6
+    display_title: Page
+    position: 6
+    display_options:
+      rendering_language: es
+      path: test_entity_field_renderered_entity/es
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+      tags:
+        - 'config:core.entity_view_display.node.article.default'

--- a/core/modules/views/tests/src/Functional/Entity/FieldRenderedEntityTranslationTest.php
+++ b/core/modules/views/tests/src/Functional/Entity/FieldRenderedEntityTranslationTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace Drupal\Tests\views\Functional\Entity;
+
+use Drupal\Core\Language\Language;
+use Drupal\Tests\views\Functional\ViewTestBase;
+use Symfony\Component\CssSelector\CssSelectorConverter;
+
+/**
+ * Tests the rendering of the 'rendered_entity' field and translations.
+ *
+ * @group views
+ */
+class FieldRenderedEntityTranslationTest extends ViewTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = ['language', 'locale', 'content_translation', 'node'];
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $testViews = ['test_entity_field_renderered_entity'];
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp($import_test_views = TRUE) {
+    parent::setUp($import_test_views);
+
+    $this->entityTypeManager = $this->container->get('entity_type.manager');
+
+    $node_type = $this->entityTypeManager->getStorage('node_type')->create([
+      'type' => 'article',
+      'label' => 'Article',
+    ]);
+    $node_type->save();
+
+    /** @var \Drupal\content_translation\ContentTranslationManagerInterface $content_translation_manager */
+    $content_translation_manager = $this->container->get('content_translation.manager');
+
+    $content_translation_manager->setEnabled('node', 'article', TRUE);
+
+    $language = $this->entityTypeManager->getStorage('configurable_language')->create([
+      'id' => 'es',
+      'label' => 'Spanish',
+    ]);
+    $language->save();
+    // Rebuild the container to setup the language path processors.
+    $this->rebuildContainer();
+  }
+
+  /**
+   * Tests that different translation mechanisms can be used for base fields.
+   */
+  public function testTranslationRows() {
+    // First, an EN node with an ES translation.
+    /** @var \Drupal\node\NodeInterface $node */
+    $node = $this->entityTypeManager->getStorage('node')->create([
+      'type' => 'article',
+      'title' => 'example EN default',
+    ]);
+    $node->save();
+
+    $translation = $node->addTranslation('es');
+    $translation->title->value = 'example ES translation';
+    $translation->sticky->value = TRUE;
+    $translation->save();
+
+    // Next, an ES node with an EN translation.
+    $node = $this->entityTypeManager->getStorage('node')->create([
+      'type' => 'article',
+      'title' => 'example ES default',
+      'langcode' => 'es',
+    ]);
+    $node->save();
+
+    $translation = $node->addTranslation('en');
+    $translation->title->value = 'example EN translation';
+    $translation->sticky->value = TRUE;
+    $translation->save();
+
+    // Next an EN node with no translation.
+    $node = $this->entityTypeManager->getStorage('node')->create([
+      'type' => 'article',
+      'title' => 'example EN no translation',
+      'sticky' => FALSE,
+    ]);
+    $node->save();
+
+    // Next an ES node with no translation.
+    $node = $this->entityTypeManager->getStorage('node')->create([
+      'type' => 'article',
+      'title' => 'example ES no translation',
+      'sticky' => FALSE,
+      'langcode' => 'es',
+    ]);
+    $node->save();
+
+    // Views are sorted first by node id ascending, and then title ascending.
+    // Confirm each node and node translation renders in its own language.
+    $this->drupalGet('test_entity_field_renderered_entity/entity_translation');
+    $this->assertRows([
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example ES translation',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+
+    // Confirm each node and node translation renders in the default language of
+    // the node.
+    $this->drupalGet('test_entity_field_renderered_entity/entity_default');
+    $this->assertRows([
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+
+    // Confirm each node and node translation renders in the site's default
+    // language (en), with fallback if node does not have en content.
+    $this->drupalGet('test_entity_field_renderered_entity/site_default');
+    $this->assertRows([
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+
+    // Confirm each node and node translation renders in the site interface
+    // language (en), with fallback if node does not have en content.
+    $this->drupalGet('test_entity_field_renderered_entity/language_interface');
+    $this->assertRows([
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+
+    // Confirm each node and node translation renders in the site interface
+    // language (es), with fallback if node does not have es content.
+    $this->drupalGet('test_entity_field_renderered_entity/language_interface', ['language' => new Language(['id' => 'es'])]);
+    $this->assertRows([
+      [
+        'title' => 'example ES translation',
+      ],
+      [
+        'title' => 'example ES translation',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+
+    // Confirm each node and node translation renders in specified language en.
+    $this->drupalGet('test_entity_field_renderered_entity/en');
+    $this->assertRows([
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN default',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example EN translation',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+
+    // Confirm each node and node translation renders in specified language es.
+    $this->drupalGet('test_entity_field_renderered_entity/es');
+    $this->assertRows([
+      [
+        'title' => 'example ES translation',
+      ],
+      [
+        'title' => 'example ES translation',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example ES default',
+      ],
+      [
+        'title' => 'example EN no translation',
+      ],
+      [
+        'title' => 'example ES no translation',
+      ],
+    ]);
+  }
+
+  /**
+   * Ensures that the rendered results are working as expected.
+   *
+   * @param array $expected
+   *   The expected rows of the result.
+   */
+  protected function assertRows(array $expected = []) {
+    $actual = [];
+    $rows = $this->cssSelect('div.views-row');
+    foreach ($rows as $row) {
+      $actual[] = [
+        'title' => $row->find('xpath', (new CssSelectorConverter())->toXPath('h2 a .field--name-title'))->getText(),
+      ];
+    }
+    $this->assertEquals($actual, $expected);
+  }
+
+}

--- a/core/tests/Drupal/KernelTests/Core/Entity/FieldableEntityDefinitionUpdateTest.php
+++ b/core/tests/Drupal/KernelTests/Core/Entity/FieldableEntityDefinitionUpdateTest.php
@@ -150,13 +150,17 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
       $this->assertEntityData($initial_rev, $initial_mul);
     }
 
+    // Enable the creation of a new base field during a fieldable entity type
+    // update.
+    $this->state->set('entity_test_update.install_new_base_field_during_update', TRUE);
+
     // Simulate a batch run since we are converting the entities one by one.
     $sandbox = [];
     do {
       $this->entityDefinitionUpdateManager->updateFieldableEntityType($updated_entity_type, $updated_field_storage_definitions, $sandbox);
     } while ($sandbox['#finished'] != 1);
 
-    $this->assertEntityTypeSchema($new_rev, $new_mul);
+    $this->assertEntityTypeSchema($new_rev, $new_mul, TRUE);
     $this->assertEntityData($initial_rev, $initial_mul);
 
     $change_list = $this->entityDefinitionUpdateManager->getChangeList();
@@ -426,8 +430,20 @@ class FieldableEntityDefinitionUpdateTest extends EntityKernelTestBase {
    *   Whether the entity type is revisionable or not.
    * @param bool $translatable
    *   Whether the entity type is translatable or not.
+   * @param bool $new_base_field
+   *   (optional) Whether a new base field was added as part of the update.
+   *   Defaults to FALSE.
    */
-  protected function assertEntityTypeSchema($revisionable, $translatable) {
+  protected function assertEntityTypeSchema($revisionable, $translatable, $new_base_field = FALSE) {
+    // Check whether the 'new_base_field' field has been installed correctly.
+    $field_storage_definition = $this->entityDefinitionUpdateManager->getFieldStorageDefinition('new_base_field', $this->entityTypeId);
+    if ($new_base_field) {
+      $this->assertNotNull($field_storage_definition);
+    }
+    else {
+      $this->assertNull($field_storage_definition);
+    }
+
     if ($revisionable && $translatable) {
       $this->assertRevisionableAndTranslatable();
     }

--- a/core/tests/Drupal/KernelTests/Core/TypedData/RecursiveContextualValidatorTest.php
+++ b/core/tests/Drupal/KernelTests/Core/TypedData/RecursiveContextualValidatorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Drupal\KernelTests\Core\TypedData;
+
+use Drupal\Core\Entity\Plugin\DataType\EntityAdapter;
+use Drupal\entity_test\Entity\EntityTest;
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\Core\TypedData\Validation\RecursiveContextualValidator
+ * @group Validation
+ */
+class RecursiveContextualValidatorTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static $modules = [
+    'entity_test',
+    'user',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->installEntitySchema('user');
+    $this->installEntitySchema('entity_test');
+  }
+
+  /**
+   * Tests recursive validation against given constraints against an entity.
+   */
+  public function testRecursiveValidate() {
+    $entity = EntityTest::create();
+    $adapter = EntityAdapter::createFromEntity($entity);
+    // This would trigger the ValidReferenceConstraint due to EntityTest
+    // defaulting uid to 1, which doesn't exist. Ensure that we don't get a
+    // violation for that.
+    $this->assertCount(0, \Drupal::typedDataManager()->getValidator()->validate($adapter, $adapter->getConstraints()));
+  }
+
+}


### PR DESCRIPTION
Update from Drupal 8.7.8 to Drupal 8.7.9.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-8), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 8 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
    - git fetch drops-8
    - git merge drops-8/update-8.7.9
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
