### PR TITLE
CORE-1762: Update settings.pantheon.php to latest Drupal 8.8.0 recommendations.

### DIFF
--- a/sites/default/settings.pantheon.php
+++ b/sites/default/settings.pantheon.php
@@ -71,14 +71,10 @@ $is_installer_url = (strpos($_SERVER['SCRIPT_NAME'], '/core/install.php') === 0)
  *
  */
 if ($is_installer_url) {
-  $config_directories = array(
-    CONFIG_SYNC_DIRECTORY => 'sites/default/files',
-  );
+  $settings['config_sync_directory'] =  'sites/default/files';
 }
 else {
-  $config_directories = array(
-    CONFIG_SYNC_DIRECTORY => 'sites/default/config',
-  );
+  $settings['config_sync_directory'] = 'sites/default/config';
 }
 
 
@@ -150,7 +146,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
  *
  */
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  $config['system.file']['path']['temporary'] = $_SERVER['HOME'] .'/tmp';
+  $settings["file_temp_path"] = $_SERVER['HOME'] .'/tmp';
 }
 
 /**


### PR DESCRIPTION
- Use $settings["file_temp_path"] instead of $config[system.file][path][temporary].
- Use $settings['config_sync_directory'] instead of $config_directories[CONFIG_SYNC_DIRECTORY].
