### PR TITLE
Update to Drupal 8.8.1. For more information, see https://www.drupal.org/project/drupal/releases/8.8.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -653,7 +653,7 @@
             "dist": {
                 "type": "path",
                 "url": "core",
-                "reference": "6b3cd6ac644f517213b17a9b359b0c9071b8a69e"
+                "reference": "2efa7c2f31a06cd72276875e68d39df692ed0d62"
             },
             "require": {
                 "asm89/stack-cors": "^1.1",
@@ -677,7 +677,7 @@
                 "ext-xml": "*",
                 "guzzlehttp/guzzle": "^6.3",
                 "masterminds/html5": "^2.1",
-                "pear/archive_tar": "^1.4.8",
+                "pear/archive_tar": "^1.4.9",
                 "php": ">=7.0.8",
                 "stack/builder": "^1.0",
                 "symfony-cmf/routing": "^1.4",
@@ -1356,16 +1356,16 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.8",
+            "version": "1.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "442bdffb7edb84c898cfd94f7ac8500e49d5bbb5"
+                "reference": "c5b00053770e1d72128252c62c2c1a12c26639f0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/442bdffb7edb84c898cfd94f7ac8500e49d5bbb5",
-                "reference": "442bdffb7edb84c898cfd94f7ac8500e49d5bbb5",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/c5b00053770e1d72128252c62c2c1a12c26639f0",
+                "reference": "c5b00053770e1d72128252c62c2c1a12c26639f0",
                 "shasum": ""
             },
             "require": {
@@ -1418,7 +1418,7 @@
                 "archive",
                 "tar"
             ],
-            "time": "2019-10-21T13:31:24+00:00"
+            "time": "2019-12-04T10:17:28+00:00"
         },
         {
             "name": "pear/console_getopt",

--- a/composer/Metapackage/CoreRecommended/composer.json
+++ b/composer/Metapackage/CoreRecommended/composer.json
@@ -7,7 +7,7 @@
         "webflo/drupal-core-strict": "*"
     },
     "require": {
-        "drupal/core": "8.8.0",
+        "drupal/core": "8.8.1",
         "asm89/stack-cors": "1.2.0",
         "composer/installers": "v1.7.0",
         "composer/semver": "1.5.0",
@@ -24,7 +24,7 @@
         "guzzlehttp/psr7": "1.6.1",
         "masterminds/html5": "2.3.0",
         "paragonie/random_compat": "v9.99.99",
-        "pear/archive_tar": "1.4.8",
+        "pear/archive_tar": "1.4.9",
         "pear/console_getopt": "v1.4.2",
         "pear/pear-core-minimal": "v1.10.9",
         "pear/pear_exception": "v1.0.0",

--- a/composer/Metapackage/PinnedDevDependencies/composer.json
+++ b/composer/Metapackage/PinnedDevDependencies/composer.json
@@ -7,7 +7,7 @@
         "webflo/drupal-core-require-dev": "*"
     },
     "require": {
-        "drupal/core": "8.8.0",
+        "drupal/core": "8.8.1",
         "behat/mink": "1.8.0 | 1.7.1.1 | 1.7.x-dev",
         "behat/mink-browserkit-driver": "1.3.3",
         "behat/mink-goutte-driver": "v1.2.1",

--- a/core/composer.json
+++ b/core/composer.json
@@ -46,7 +46,7 @@
         "zendframework/zend-diactoros": "^1.8",
         "composer/semver": "^1.0",
         "asm89/stack-cors": "^1.1",
-        "pear/archive_tar": "^1.4.8"
+        "pear/archive_tar": "^1.4.9"
     },
     "conflict": {
         "drupal/pathauto": "<1.6",

--- a/core/includes/install.core.inc
+++ b/core/includes/install.core.inc
@@ -425,10 +425,9 @@ function install_begin_request($class_loader, &$install_state) {
   }
   $GLOBALS['conf']['container_service_providers']['InstallerConfigOverride'] = 'Drupal\Core\Installer\ConfigOverride';
 
-  // Only allow dumping the container once the hash salt has been created. Note,
-  // InstallerKernel::createFromRequest() is not used because Settings is
+  // Note, InstallerKernel::createFromRequest() is not used because Settings is
   // already initialized.
-  $kernel = new InstallerKernel($environment, $class_loader, (bool) Settings::get('hash_salt', FALSE));
+  $kernel = new InstallerKernel($environment, $class_loader, FALSE);
   $kernel::bootEnvironment();
   $kernel->setSitePath($site_path);
   $kernel->boot();

--- a/core/lib/Drupal.php
+++ b/core/lib/Drupal.php
@@ -82,7 +82,7 @@ class Drupal {
   /**
    * The current system version.
    */
-  const VERSION = '8.8.0';
+  const VERSION = '8.8.1';
 
   /**
    * Core API compatibility.

--- a/core/lib/Drupal/Core/Archiver/Tar.php
+++ b/core/lib/Drupal/Core/Archiver/Tar.php
@@ -54,10 +54,10 @@ class Tar implements ArchiverInterface {
    */
   public function extract($path, array $files = []) {
     if ($files) {
-      $this->tar->extractList($files, $path);
+      $this->tar->extractList($files, $path, '', FALSE, FALSE);
     }
     else {
-      $this->tar->extract($path);
+      $this->tar->extract($path, FALSE, FALSE);
     }
 
     return $this;

--- a/core/lib/Drupal/Core/Installer/InstallerKernel.php
+++ b/core/lib/Drupal/Core/Installer/InstallerKernel.php
@@ -15,6 +15,8 @@ class InstallerKernel extends DrupalKernel {
   protected function initializeContainer() {
     // Always force a container rebuild.
     $this->containerNeedsRebuild = TRUE;
+    // Ensure the InstallerKernel's container is not dumped.
+    $this->allowDumping = FALSE;
     $container = parent::initializeContainer();
     return $container;
   }

--- a/core/modules/config/src/Form/ConfigImportForm.php
+++ b/core/modules/config/src/Form/ConfigImportForm.php
@@ -131,7 +131,7 @@ class ConfigImportForm extends FormBase {
         foreach ($archiver->listContent() as $file) {
           $files[] = $file['filename'];
         }
-        $archiver->extractList($files, $this->settings->get('config_sync_directory'));
+        $archiver->extractList($files, $this->settings->get('config_sync_directory'), '', FALSE, FALSE);
         $this->messenger()->addStatus($this->t('Your configuration files were successfully uploaded and are ready for import.'));
         $form_state->setRedirect('config.sync');
       }

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -992,7 +992,7 @@ function _file_save_upload_single(\SplFileInfo $file_info, $form_field_name, $va
   $values = [
     'uid' => $user->id(),
     'status' => 0,
-    'filename' => $file_info->getClientOriginalName(),
+    'filename' => trim($file_info->getClientOriginalName(), '.'),
     'uri' => $file_info->getRealPath(),
     'filesize' => $file_info->getSize(),
   ];

--- a/core/modules/file/tests/src/Functional/FileManagedFileElementTest.php
+++ b/core/modules/file/tests/src/Functional/FileManagedFileElementTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\file\Functional;
 
+use Drupal\file\Entity\File;
+
 /**
  * Tests the 'managed_file' element type.
  *
@@ -154,6 +156,21 @@ class FileManagedFileElementTest extends FileFieldTestBase {
     // We expect the title 'Managed <em>file & butter</em>' which got escaped
     // via a t() call before.
     $this->assertRaw('The file referenced by the Managed <em>file &amp; butter</em> field does not exist.');
+  }
+
+  /**
+   * Tests file names have leading . removed.
+   */
+  public function testFileNameTrim() {
+    file_put_contents('public://.leading-period.txt', $this->randomString(32));
+    $last_fid_prior = $this->getLastFileId();
+    $this->drupalPostForm('file/test/0/0/0', [
+      'files[file]' => \Drupal::service('file_system')->realpath('public://.leading-period.txt'),
+    ], t('Save'));
+    $next_fid = $this->getLastFileId();
+    $this->assertGreaterThan($last_fid_prior, $next_fid);
+    $file = File::load($next_fid);
+    $this->assertEquals('leading-period.txt', $file->getFilename());
   }
 
   /**

--- a/core/modules/media_library/tests/src/FunctionalJavascript/WidgetUploadTest.php
+++ b/core/modules/media_library/tests/src/FunctionalJavascript/WidgetUploadTest.php
@@ -568,6 +568,29 @@ class WidgetUploadTest extends MediaLibraryTestBase {
     $this->pressInsertSelected('Added one media item.');
     $assert_session->pageTextContains($file_system->basename($jpg_uri_2));
 
+    // Assert users can not select media items they do not have access to.
+    $unpublished_media = Media::create([
+      'name' => 'Mosquito',
+      'bundle' => 'type_one',
+      'field_media_test' => 'Mosquito',
+      'status' => FALSE,
+    ]);
+    $unpublished_media->save();
+    $this->openMediaLibraryForField('field_unlimited_media');
+    $this->switchToMediaType('Three');
+    // Set the hidden field with the current selection via JavaScript and upload
+    // a file.
+    $this->getSession()->executeScript("jQuery('.js-media-library-add-form-current-selection').val('1,2,{$unpublished_media->id()}')");
+    $this->addMediaFileToField('Add files', $this->container->get('file_system')->realpath($png_uri_3));
+    // Assert the pre-selected items are shown.
+    $this->getSelectionArea();
+    // Assert the published items are selected and the unpublished item is not
+    // selected.
+    $this->waitForText(Media::load(1)->label());
+    $this->waitForText(Media::load(2)->label());
+    $assert_session->pageTextNotContains('Mosquito');
+    $page->find('css', '.ui-dialog-titlebar-close')->click();
+
     // Assert we can also remove selected items from the selection area in the
     // upload form.
     $this->openMediaLibraryForField('field_unlimited_media');

--- a/core/modules/system/tests/modules/system_test/src/Controller/SystemTestController.php
+++ b/core/modules/system/tests/modules/system_test/src/Controller/SystemTestController.php
@@ -406,4 +406,12 @@ class SystemTestController extends ControllerBase implements TrustedCallbackInte
     return ['preRenderCacheTags'];
   }
 
+  /**
+   * Use a plain Symfony response object to output the current install_profile.
+   */
+  public function getInstallProfile() {
+    $install_profile = \Drupal::installProfile() ?: 'NONE';
+    return new Response('install_profile: ' . $install_profile);
+  }
+
 }

--- a/core/modules/system/tests/modules/system_test/system_test.routing.yml
+++ b/core/modules/system/tests/modules/system_test/system_test.routing.yml
@@ -204,3 +204,10 @@ system_test.custom_cache_control:
     _controller: '\Drupal\system_test\Controller\SystemTestController::getCacheableResponseWithCustomCacheControl'
   requirements:
     _access: 'TRUE'
+
+system_test.install_profile:
+  path: '/system-test/get-install-profile'
+  defaults:
+    _controller: '\Drupal\system_test\Controller\SystemTestController::getInstallProfile'
+  requirements:
+    _access: 'TRUE'

--- a/core/tests/Drupal/FunctionalTests/Installer/InstallerPostInstallTest.php
+++ b/core/tests/Drupal/FunctionalTests/Installer/InstallerPostInstallTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\FunctionalTests\Installer;
+
+/**
+ * Tests re-visiting the installer after a successful installation.
+ *
+ * @group Installer
+ */
+class InstallerPostInstallTest extends InstallerTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'minimal';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * Confirms that visiting the installer does not break things post-install.
+   */
+  public function testVisitInstallerPostInstall() {
+    \Drupal::service('module_installer')->install(['system_test']);
+    // Clear caches to ensure that system_test's routes are available.
+    $this->resetAll();
+    // Confirm that the install_profile is correct.
+    $this->drupalGet('/system-test/get-install-profile');
+    $this->assertText('minimal');
+    // Make an anonymous visit to the installer
+    $this->drupalLogout();
+    $this->visitInstaller();
+    // Ensure that the install profile is still correct.
+    $this->drupalGet('/system-test/get-install-profile');
+    $this->assertText('minimal');
+  }
+
+}

--- a/vendor/composer/installed.json
+++ b/vendor/composer/installed.json
@@ -665,7 +665,7 @@
         "dist": {
             "type": "path",
             "url": "core",
-            "reference": "6b3cd6ac644f517213b17a9b359b0c9071b8a69e"
+            "reference": "2efa7c2f31a06cd72276875e68d39df692ed0d62"
         },
         "require": {
             "asm89/stack-cors": "^1.1",
@@ -689,7 +689,7 @@
             "ext-xml": "*",
             "guzzlehttp/guzzle": "^6.3",
             "masterminds/html5": "^2.1",
-            "pear/archive_tar": "^1.4.8",
+            "pear/archive_tar": "^1.4.9",
             "php": ">=7.0.8",
             "stack/builder": "^1.0",
             "symfony-cmf/routing": "^1.4",
@@ -1387,17 +1387,17 @@
     },
     {
         "name": "pear/archive_tar",
-        "version": "1.4.8",
-        "version_normalized": "1.4.8.0",
+        "version": "1.4.9",
+        "version_normalized": "1.4.9.0",
         "source": {
             "type": "git",
             "url": "https://github.com/pear/Archive_Tar.git",
-            "reference": "442bdffb7edb84c898cfd94f7ac8500e49d5bbb5"
+            "reference": "c5b00053770e1d72128252c62c2c1a12c26639f0"
         },
         "dist": {
             "type": "zip",
-            "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/442bdffb7edb84c898cfd94f7ac8500e49d5bbb5",
-            "reference": "442bdffb7edb84c898cfd94f7ac8500e49d5bbb5",
+            "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/c5b00053770e1d72128252c62c2c1a12c26639f0",
+            "reference": "c5b00053770e1d72128252c62c2c1a12c26639f0",
             "shasum": ""
         },
         "require": {
@@ -1412,7 +1412,7 @@
             "ext-xz": "Lzma2 compression support.",
             "ext-zlib": "Gzip compression support."
         },
-        "time": "2019-10-21T13:31:24+00:00",
+        "time": "2019-12-04T10:17:28+00:00",
         "type": "library",
         "extra": {
             "branch-alias": {

--- a/vendor/pear/archive_tar/Archive/Tar.php
+++ b/vendor/pear/archive_tar/Archive/Tar.php
@@ -312,11 +312,12 @@ class Archive_Tar extends PEAR
     /**
      * @param string $p_path
      * @param bool $p_preserve
+     * @param bool $p_symlinks
      * @return bool
      */
-    public function extract($p_path = '', $p_preserve = false)
+    public function extract($p_path = '', $p_preserve = false, $p_symlinks = true)
     {
-        return $this->extractModify($p_path, '', $p_preserve);
+        return $this->extractModify($p_path, '', $p_preserve, $p_symlinks);
     }
 
     /**
@@ -557,11 +558,12 @@ class Archive_Tar extends PEAR
      *                               removed if present at the beginning of
      *                               the file/dir path.
      * @param boolean $p_preserve Preserve user/group ownership of files
+     * @param boolean $p_symlinks Allow symlinks.
      *
      * @return boolean true on success, false on error.
      * @see    extractList()
      */
-    public function extractModify($p_path, $p_remove_path, $p_preserve = false)
+    public function extractModify($p_path, $p_remove_path, $p_preserve = false, $p_symlinks = true)
     {
         $v_result = true;
         $v_list_detail = array();
@@ -573,7 +575,8 @@ class Archive_Tar extends PEAR
                 "complete",
                 0,
                 $p_remove_path,
-                $p_preserve
+                $p_preserve,
+                $p_symlinks
             );
             $this->_close();
         }
@@ -617,11 +620,12 @@ class Archive_Tar extends PEAR
      *                               removed if present at the beginning of
      *                               the file/dir path.
      * @param boolean $p_preserve Preserve user/group ownership of files
+     * @param boolean $p_symlinks Allow symlinks.
      *
      * @return true on success, false on error.
      * @see    extractModify()
      */
-    public function extractList($p_filelist, $p_path = '', $p_remove_path = '', $p_preserve = false)
+    public function extractList($p_filelist, $p_path = '', $p_remove_path = '', $p_preserve = false, $p_symlinks = true)
     {
         $v_result = true;
         $v_list_detail = array();
@@ -642,7 +646,8 @@ class Archive_Tar extends PEAR
                 "partial",
                 $v_list,
                 $p_remove_path,
-                $p_preserve
+                $p_preserve,
+                $p_symlinks
             );
             $this->_close();
         }
@@ -1917,6 +1922,7 @@ class Archive_Tar extends PEAR
      * @param string $p_file_list
      * @param string $p_remove_path
      * @param bool $p_preserve
+     * @param bool $p_symlinks
      * @return bool
      */
     public function _extractList(
@@ -1925,7 +1931,8 @@ class Archive_Tar extends PEAR
         $p_mode,
         $p_file_list,
         $p_remove_path,
-        $p_preserve = false
+        $p_preserve = false,
+        $p_symlinks = true
     )
     {
         $v_result = true;
@@ -2108,6 +2115,13 @@ class Archive_Tar extends PEAR
                             }
                         }
                     } elseif ($v_header['typeflag'] == "2") {
+                        if (!$p_symlinks) {
+                            $this->_warning('Symbolic links are not allowed. '
+                                . 'Unable to extract {'
+                                . $v_header['filename'] . '}'
+                            );
+                            return false;
+                        }
                         if (@file_exists($v_header['filename'])) {
                             @unlink($v_header['filename']);
                         }

--- a/vendor/pear/archive_tar/package.xml
+++ b/vendor/pear/archive_tar/package.xml
@@ -32,10 +32,10 @@ Also Lzma2 compressed archives are supported with xz extension.</description>
   <email>stig@php.net</email>
   <active>no</active>
  </helper>
- <date>2019-10-21</date>
- <time>13:29:44</time>
+ <date>2019-12-04</date>
+ <time>09:25:16</time>
  <version>
-  <release>1.4.8</release>
+  <release>1.4.9</release>
   <api>1.4.0</api>
  </version>
  <stability>
@@ -44,7 +44,7 @@ Also Lzma2 compressed archives are supported with xz extension.</description>
  </stability>
  <license uri="http://www.opensource.org/licenses/bsd-license.php">New BSD License</license>
  <notes>
-* Fix Bug #23852: PHP 7.4 - Archive_Tar-&gt;_readHeader throws deprecation [mrook]
+* Implement Feature #23861: Add option to disallow symlinks [mrook]
  </notes>
  <contents>
   <dir name="/">
@@ -74,6 +74,21 @@ Also Lzma2 compressed archives are supported with xz extension.</description>
  </dependencies>
  <phprelease />
  <changelog>
+  <release>
+   <version>
+    <release>1.4.8</release>
+    <api>1.4.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2019-10-21</date>
+   <license uri="http://www.opensource.org/licenses/bsd-license.php">New BSD License</license>
+   <notes>
+* Fix Bug #23852: PHP 7.4 - Archive_Tar-&gt;_readHeader throws deprecation [mrook]
+   </notes>
+  </release>
   <release>
    <version>
     <release>1.4.7</release>


### PR DESCRIPTION
Update from Drupal 8.8.0 to Drupal 8.8.1.

Before merging this PR, check the [build results on CircleCI](https://circleci.com/gh/pantheon-systems/drops-8), and then visit the test site and confirm that the correct version of Drupal was, in fact, installed and tested.

Optionally, you may also create your own test site:

  - Create a new Drupal 8 site on Pantheon.
  - When site creation is finished, visit dashboard.
  - Switch to "git" mode.
  - Clone your site locally.
  - Apply the files from this PR on top of your local checkout.
    - git remote add drops-8 git@github.com:pantheon-systems/drops-8.git
    - git fetch drops-8
    - git merge drops-8/update-8.8.1
  - Push your files back up to Pantheon.
  - Switch back to sftp mode.
  - Visit your site and step through the installation process.
