### PR TITLE
Upgrade default PHP version to 8.1

### DIFF
--- a/pantheon.upstream.yml
+++ b/pantheon.upstream.yml
@@ -3,7 +3,7 @@
 # Override the defaults specified here in a site-specific `pantheon.yml` file.
 # For more information see: https://pantheon.io/docs/pantheon-upstream-yml
 api_version: 1
-php_version: 7.4
+php_version: 8.1
 
 # See https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb
 database:


### PR DESCRIPTION
Updates PHP to 8.1 in `pantheon.upstream.yml`. If PHP is set in `pantheon.yml`, this value is ignored.